### PR TITLE
feat: Feature 1.3 — Observability (debug logging, metrics, OTel spans)

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends
@@ -6,6 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.db import get_db
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["health"])
 
@@ -30,6 +33,8 @@ async def readiness_check(
         checks["postgres"] = "ok"
     except Exception:  # noqa: BLE001
         checks["postgres"] = "error"
+
+    logger.debug("Readiness check: %s", checks)
 
     # Additional checks (redis, qdrant, minio, ollama) added as services come online.
     all_ok = all(v == "ok" for v in checks.values())

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,0 +1,35 @@
+"""Module-level OTel metric instruments for authentication events.
+
+Import and call these from the auth router (1.4) to record auth activity.
+All instruments are created once at module import time.
+
+Usage::
+
+    from app.core.metrics import login_attempts
+
+    login_attempts.add(1, {"result": "success"})
+    login_attempts.add(1, {"result": "failure"})
+    login_attempts.add(1, {"result": "locked"})
+"""
+
+from app.core.telemetry import meter
+
+login_attempts = meter.create_counter(
+    "opencase.auth.login_attempts",
+    description="Login attempts by result",  # attrs: result=(success|failure|locked)
+)
+
+mfa_challenges = meter.create_counter(
+    "opencase.auth.mfa_challenges",
+    description="MFA TOTP challenge outcomes",  # attrs: result=(success|failure)
+)
+
+token_refresh_attempts = meter.create_counter(
+    "opencase.auth.token_refresh_attempts",
+    description="Token refresh attempts",
+)
+
+active_sessions = meter.create_up_down_counter(
+    "opencase.auth.active_sessions",
+    description="Currently active sessions (access tokens issued minus logouts)",
+)

--- a/backend/app/core/telemetry.py
+++ b/backend/app/core/telemetry.py
@@ -46,8 +46,12 @@ Use the module-level ``meter`` to create counters, histograms, etc.::
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 from opentelemetry import metrics, trace
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import (
     ConsoleMetricExporter,
@@ -92,13 +96,23 @@ def setup_telemetry(settings: Settings) -> TracerProvider | None:
             "service.version": settings.app_version,
         }
     )
+    logger.debug(
+        "OTel resource created: service=%s version=%s",
+        settings.otel.service_name,
+        settings.app_version,
+    )
 
     # Tracing
     sampler = TraceIdRatioBased(settings.otel.sample_rate)
     provider = TracerProvider(resource=resource, sampler=sampler)
+    logger.debug(
+        "TracerProvider created: sample_rate=%s",
+        settings.otel.sample_rate,
+    )
 
     if settings.otel.exporter == "console":
         provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+        logger.debug("Span exporter wired: console")
 
     trace.set_tracer_provider(provider)
     _tracer_provider = provider
@@ -113,6 +127,7 @@ def setup_telemetry(settings: Settings) -> TracerProvider | None:
             resource=resource, metric_readers=[metric_reader]
         )
         metrics.set_meter_provider(meter_provider)
+        logger.debug("Metric exporter wired: console (interval=60s)")
 
     logger.info(
         "OpenTelemetry enabled: exporter=%s, service=%s",
@@ -120,3 +135,24 @@ def setup_telemetry(settings: Settings) -> TracerProvider | None:
         settings.otel.service_name,
     )
     return provider
+
+
+def configure_instrumentation(app: "FastAPI", settings: Settings) -> None:
+    """Wire OTel instrumentors for FastAPI and SQLAlchemy.
+
+    Called from main.py after the FastAPI app and DB engine are both created.
+    Lazy imports keep telemetry.py free of circular dependencies at module level.
+    ``app`` is passed in rather than imported — telemetry.py never imports main.py.
+    """
+    if not settings.otel.enabled:
+        logger.debug("OTel disabled — skipping instrumentation")
+        return
+
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+
+    from app.db.session import engine
+
+    FastAPIInstrumentor.instrument_app(app)
+    SQLAlchemyInstrumentor().instrument(engine=engine)
+    logger.debug("OTel instrumentors wired: FastAPI + SQLAlchemy")

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -4,11 +4,25 @@ Engine is created once at startup from settings.db. All async routes receive
 an AsyncSession via the get_db dependency.
 """
 
+import logging
 from collections.abc import AsyncGenerator
+from urllib.parse import urlparse
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_parsed = urlparse(settings.db.url)
+logger.debug(
+    "DB engine initialised: host=%s port=%s pool_size=%d max_overflow=%d pre_ping=%s",
+    _parsed.hostname,
+    _parsed.port,
+    settings.db.pool_size,
+    settings.db.max_overflow,
+    settings.db.pool_pre_ping,
+)
 
 engine = create_async_engine(
     settings.db.url,
@@ -26,5 +40,7 @@ AsyncSessionLocal = async_sessionmaker(
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    logger.debug("DB session opened")
     async with AsyncSessionLocal() as session:
         yield session
+    logger.debug("DB session closed")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,9 @@
 from fastapi import FastAPI
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
 from app.api.health import router as health_router
 from app.core.config import settings
 from app.core.logging import setup_logging
-from app.core.telemetry import setup_telemetry
+from app.core.telemetry import configure_instrumentation, setup_telemetry
 
 setup_logging(settings.log_level, settings.log_output)
 setup_telemetry(settings)
@@ -18,5 +17,4 @@ app = FastAPI(
 
 app.include_router(health_router)
 
-if settings.otel.enabled:
-    FastAPIInstrumentor.instrument_app(app)
+configure_instrumentation(app, settings)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -12,6 +12,7 @@
 | 0.6 | `.env.example` | Done |
 | 0.7 | CI: GitHub Actions (format/lint, unit tests, integration tests, AI code review, container build) | Done |
 | 0.8 | Docker Compose — PostgreSQL service (volume, healthcheck, local dev + integration test target) | Done |
+| 0.9 | Jaeger — distributed tracing collector (all-in-one container, OTLP ingest, UI, integration test support) | Pending |
 
 ## Feature 1 — API
 
@@ -19,7 +20,7 @@
 | --- | --- | --- | --- | --- |
 | 1.1 | Configuration + env vars (ApiSettings, AuthSettings, DbSettings) | Done | Done | Pending |
 | 1.2 | Database foundation (User, Firm, Matter models + Alembic) | Done | Done | Pending |
-| 1.3 | Observability (auth spans/metrics, DB tracing) | Pending | Pending | Pending |
+| 1.3 | Observability (auth spans/metrics, DB tracing) | Done | Done | Pending |
 | 1.4 | Authentication (JWT, TOTP MFA, login/logout/refresh) | Pending | Pending | Pending |
 | 1.5 | RBAC middleware (role enforcement, `build_qdrant_filter()`) | Pending | Pending | Pending |
 | 1.6 | Python REST client SDK (backend/sdk/) | Pending | Pending | Pending |


### PR DESCRIPTION
## Summary

- App-level debug logging added to `session.py`, `health.py`, and `telemetry.py` — controlled by `OPENCASE_LOG_LEVEL`
- `metrics.py` scaffolds 4 auth OTel instruments (`login_attempts`, `mfa_challenges`, `token_refresh_attempts`, `active_sessions`) ready for the 1.4 auth router to wire up
- `configure_instrumentation(app, settings)` extracted into `telemetry.py` — wires `FastAPIInstrumentor` + `SQLAlchemyInstrumentor` via lazy imports; `main.py` calls it after app creation

## Notes

- No circular dependency: `telemetry.py` never imports `main.py` — the `app` object is passed as a parameter; `FastAPI` type hint uses `TYPE_CHECKING` so it's runtime-free
- Tests deferred to Feature 0.9 (Jaeger) — integration tests will verify spans and metrics arrive in the remote collector, which is more meaningful than unit-testing Python object creation

## Test plan

- [ ] CI passes (ruff, mypy, pytest)
- [ ] Integration tests deferred to 0.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)