### PR TITLE
feat: CLI built on SDK (Feature 1.7)

### DIFF
--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -68,3 +68,15 @@ jobs:
       - name: Run type checker — sdk
         working-directory: sdk
         run: uv run mypy opencase/
+
+      - name: Check formatting — cli
+        working-directory: cli
+        run: uv run ruff format --check .
+
+      - name: Run linter — cli
+        working-directory: cli
+        run: uv run ruff check .
+
+      - name: Run type checker — cli
+        working-directory: cli
+        run: uv run mypy opencase_cli/

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,6 +55,15 @@ jobs:
             --cov-report=json:coverage.json \
             -v
 
+      - name: Run CLI unit tests with coverage
+        working-directory: cli
+        run: |
+          uv run pytest \
+            --cov=opencase_cli \
+            --cov-report=term-missing \
+            --cov-report=json:coverage.json \
+            -v
+
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
         if: always()
@@ -63,6 +72,7 @@ jobs:
           path: |
             backend/coverage.json
             sdk/coverage.json
+            cli/coverage.json
           retention-days: 30
 
       - name: Coverage summary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,10 @@ repos:
     hooks:
       - id: ruff-format
         args: [--check]
-        files: ^(backend|shared|sdk)/
+        files: ^(backend|shared|sdk|cli)/
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-        files: ^(backend|shared|sdk)/
+        files: ^(backend|shared|sdk|cli)/
 
   - repo: local
     hooks:
@@ -56,3 +56,18 @@ repos:
         language: system
         pass_filenames: false
         files: ^sdk/
+
+      - id: mypy-cli
+        name: mypy (cli)
+        entry: bash -c 'unset VIRTUAL_ENV && cd cli && uv run mypy opencase_cli/'
+        language: system
+        pass_filenames: false
+        files: ^cli/
+        types: [python]
+
+      - id: pytest-cli
+        name: pytest (cli)
+        entry: bash -c 'unset VIRTUAL_ENV && cd cli && uv run python -m pytest -x -q --cov=opencase_cli --cov-report=term-missing'
+        language: system
+        pass_filenames: false
+        files: ^cli/

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,18 @@
+# opencase-cli
+
+Command-line interface for the OpenCase API, built on the
+[opencase-sdk](../sdk/) Python client.
+
+## Installation
+
+```bash
+uv sync
+```
+
+## Usage
+
+```bash
+opencase --help
+opencase health
+opencase login --email user@firm.com
+```

--- a/cli/opencase_cli/__init__.py
+++ b/cli/opencase_cli/__init__.py
@@ -1,0 +1,3 @@
+"""OpenCase CLI — command-line interface for the OpenCase API."""
+
+__version__ = "0.1.0"

--- a/cli/opencase_cli/commands/auth.py
+++ b/cli/opencase_cli/commands/auth.py
@@ -1,0 +1,79 @@
+"""Authentication commands — login, logout, whoami."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+from shared.models.auth import MfaRequiredResponse
+
+from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
+from opencase_cli.output import handle_errors, print_json, print_model, print_success
+from opencase_cli.tokens import clear_tokens, save_tokens
+
+
+def login(
+    email: Annotated[
+        str | None,
+        typer.Option("--email", "-e", help="Account email address."),
+    ] = None,
+    password: Annotated[
+        str | None,
+        typer.Option("--password", "-p", help="Account password.", hide_input=True),
+    ] = None,
+    totp_code: Annotated[
+        str | None,
+        typer.Option("--totp-code", help="TOTP code (skip interactive MFA prompt)."),
+    ] = None,
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Authenticate with email and password."""
+    if email is None:
+        email = typer.prompt("Email")
+    if password is None:
+        password = typer.prompt("Password", hide_input=True)
+
+    client = get_client(base_url, timeout)
+    with handle_errors(), client:
+        result = client.login(email=email, password=password)
+
+        if isinstance(result, MfaRequiredResponse):
+            if totp_code is None:
+                totp_code = typer.prompt("TOTP code")
+            result = client.verify_mfa(mfa_token=result.mfa_token, totp_code=totp_code)
+
+        save_tokens(result.access_token, result.refresh_token)
+
+        if json_output:
+            print_json({"authenticated": True})
+        else:
+            print_success("Logged in successfully.")
+
+
+def logout(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Log out and clear stored tokens."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        client.logout()
+        clear_tokens()
+        if json_output:
+            print_json({"logged_out": True})
+        else:
+            print_success("Logged out.")
+
+
+def whoami(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Show current authenticated user."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_model(client.get_current_user(), json_mode=json_output)

--- a/cli/opencase_cli/commands/auth.py
+++ b/cli/opencase_cli/commands/auth.py
@@ -19,7 +19,12 @@ def login(
     ] = None,
     password: Annotated[
         str | None,
-        typer.Option("--password", "-p", help="Account password.", hide_input=True),
+        typer.Option(
+            "--password",
+            "-p",
+            help="Account password (prefer interactive prompt to avoid shell history).",
+            hide_input=True,
+        ),
     ] = None,
     totp_code: Annotated[
         str | None,
@@ -59,13 +64,15 @@ def logout(
 ) -> None:
     """Log out and clear stored tokens."""
     client = get_client(base_url, timeout, authenticated=True)
-    with handle_errors(), client:
-        client.logout()
+    try:
+        with handle_errors(), client:
+            client.logout()
+    finally:
         clear_tokens()
-        if json_output:
-            print_json({"logged_out": True})
-        else:
-            print_success("Logged out.")
+    if json_output:
+        print_json({"logged_out": True})
+    else:
+        print_success("Logged out.")
 
 
 def whoami(

--- a/cli/opencase_cli/commands/firms.py
+++ b/cli/opencase_cli/commands/firms.py
@@ -1,0 +1,22 @@
+"""Firm subcommands."""
+
+from __future__ import annotations
+
+import typer
+
+from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
+from opencase_cli.output import handle_errors, print_model
+
+app = typer.Typer(help="Firm information.", no_args_is_help=True)
+
+
+@app.command("get")
+def get_firm(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Show current firm details."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_model(client.get_firm(), json_mode=json_output)

--- a/cli/opencase_cli/commands/health.py
+++ b/cli/opencase_cli/commands/health.py
@@ -1,0 +1,31 @@
+"""Health and readiness check commands."""
+
+from __future__ import annotations
+
+from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
+from opencase_cli.output import handle_errors, print_model
+
+
+def health(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Check API health (unauthenticated)."""
+    client = get_client(base_url, timeout)
+    with handle_errors(), client:
+        print_model(client.health(), json_mode=json_output)
+
+
+def ready(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Check API readiness and service dependencies."""
+    client = get_client(base_url, timeout)
+    with handle_errors(), client:
+        resp = client.readiness()
+        print_model(resp, json_mode=json_output)
+        if resp.status == "degraded":
+            raise SystemExit(1)

--- a/cli/opencase_cli/commands/matters.py
+++ b/cli/opencase_cli/commands/matters.py
@@ -1,0 +1,167 @@
+"""Matter management subcommands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
+from opencase_cli.output import (
+    handle_errors,
+    print_error,
+    print_json,
+    print_list,
+    print_model,
+    print_success,
+)
+
+app = typer.Typer(help="Matter management.", no_args_is_help=True)
+
+_MATTER_COLUMNS = ["id", "name", "status", "legal_hold", "client_id"]
+_ACCESS_COLUMNS = [
+    "user_id",
+    "matter_id",
+    "view_work_product",
+    "assigned_at",
+]
+
+
+@app.command("list")
+def list_matters(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """List all matters."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_list(
+            client.list_matters(),
+            columns=_MATTER_COLUMNS,
+            json_mode=json_output,
+        )
+
+
+@app.command("get")
+def get_matter(
+    matter_id: Annotated[str, typer.Argument(help="Matter UUID.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Get a matter by ID."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_model(client.get_matter(matter_id), json_mode=json_output)
+
+
+@app.command("create")
+def create_matter(
+    name: Annotated[str, typer.Option("--name", help="Matter name.")],
+    client_id: Annotated[str, typer.Option("--client-id", help="Client UUID.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Create a new matter."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        matter = client.create_matter(name=name, client_id=client_id)
+        if json_output:
+            print_model(matter, json_mode=True)
+        else:
+            print_success(f"Matter '{matter.name}' created.")
+
+
+@app.command("update")
+def update_matter(
+    matter_id: Annotated[str, typer.Argument(help="Matter UUID.")],
+    name: Annotated[str | None, typer.Option("--name")] = None,
+    status: Annotated[str | None, typer.Option("--status")] = None,
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Update a matter (only provided fields are changed)."""
+    fields: dict[str, object] = {}
+    if name is not None:
+        fields["name"] = name
+    if status is not None:
+        fields["status"] = status
+
+    if not fields:
+        print_error("No fields to update. Provide at least one option.")
+        raise SystemExit(1)
+
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        matter = client.update_matter(matter_id, **fields)
+        if json_output:
+            print_model(matter, json_mode=True)
+        else:
+            print_success(f"Matter '{matter.name}' updated.")
+
+
+# -- access subcommands ------------------------------------------------------
+
+
+@app.command("access-list")
+def list_access(
+    matter_id: Annotated[str, typer.Argument(help="Matter UUID.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """List users with access to a matter."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_list(
+            client.list_matter_access(matter_id),
+            columns=_ACCESS_COLUMNS,
+            json_mode=json_output,
+        )
+
+
+@app.command("access-grant")
+def grant_access(
+    matter_id: Annotated[str, typer.Argument(help="Matter UUID.")],
+    user_id: Annotated[str, typer.Option("--user-id", help="User UUID.")],
+    view_work_product: Annotated[
+        bool,
+        typer.Option("--view-work-product", help="Grant work product access."),
+    ] = False,
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Grant a user access to a matter."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        result = client.grant_matter_access(
+            matter_id,
+            user_id=user_id,
+            view_work_product=view_work_product,
+        )
+        if json_output:
+            print_model(result, json_mode=True)
+        else:
+            print_success("Access granted.")
+
+
+@app.command("access-revoke")
+def revoke_access(
+    matter_id: Annotated[str, typer.Argument(help="Matter UUID.")],
+    user_id: Annotated[str, typer.Option("--user-id", help="User UUID to revoke.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Revoke a user's access to a matter."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        result = client.revoke_matter_access(matter_id, user_id)
+        if json_output:
+            print_json({"detail": result.detail})
+        else:
+            print_success(result.detail)

--- a/cli/opencase_cli/commands/mfa.py
+++ b/cli/opencase_cli/commands/mfa.py
@@ -1,0 +1,73 @@
+"""MFA management subcommands — setup, confirm, disable."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
+from opencase_cli.output import handle_errors, print_model, print_success
+
+app = typer.Typer(help="Manage multi-factor authentication.", no_args_is_help=True)
+
+
+@app.command()
+def setup(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Begin MFA setup — shows TOTP secret and provisioning URI."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_model(client.mfa_setup(), json_mode=json_output)
+
+
+@app.command()
+def confirm(
+    totp_code: Annotated[
+        str | None,
+        typer.Option("--totp-code", help="TOTP code to confirm setup."),
+    ] = None,
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Confirm MFA setup with a TOTP code."""
+    if totp_code is None:
+        totp_code = typer.prompt("TOTP code")
+
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        resp = client.mfa_confirm(totp_code=totp_code)
+        if json_output:
+            print_model(resp, json_mode=True)
+        else:
+            msg = "MFA enabled." if resp.enabled else "MFA confirmation failed."
+            print_success(msg)
+
+
+@app.command()
+def disable(
+    totp_code: Annotated[
+        str | None,
+        typer.Option("--totp-code", help="TOTP code to disable MFA."),
+    ] = None,
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Disable MFA with a TOTP code."""
+    if totp_code is None:
+        totp_code = typer.prompt("TOTP code")
+
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        resp = client.mfa_disable(totp_code=totp_code)
+        if json_output:
+            print_model(resp, json_mode=True)
+        else:
+            print_success(
+                "MFA disabled." if not resp.enabled else "MFA disable failed."
+            )

--- a/cli/opencase_cli/commands/users.py
+++ b/cli/opencase_cli/commands/users.py
@@ -1,0 +1,128 @@
+"""User management subcommands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
+from opencase_cli.output import (
+    handle_errors,
+    print_error,
+    print_list,
+    print_model,
+    print_success,
+)
+
+app = typer.Typer(help="User management.", no_args_is_help=True)
+
+_USER_COLUMNS = ["id", "email", "first_name", "last_name", "role", "is_active"]
+
+
+@app.command("list")
+def list_users(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """List all users in the firm."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_list(client.list_users(), columns=_USER_COLUMNS, json_mode=json_output)
+
+
+@app.command("get")
+def get_user(
+    user_id: Annotated[str, typer.Argument(help="User UUID.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Get a user by ID."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_model(client.get_user(user_id), json_mode=json_output)
+
+
+@app.command("create")
+def create_user(
+    email: Annotated[str, typer.Option("--email", help="Email address.")],
+    password: Annotated[
+        str,
+        typer.Option("--password", help="Password.", hide_input=True),
+    ],
+    first_name: Annotated[str, typer.Option("--first-name", help="First name.")],
+    last_name: Annotated[str, typer.Option("--last-name", help="Last name.")],
+    role: Annotated[
+        str,
+        typer.Option("--role", help="Role: admin|attorney|paralegal|investigator."),
+    ],
+    title: Annotated[str | None, typer.Option("--title", help="Title.")] = None,
+    middle_initial: Annotated[
+        str | None, typer.Option("--middle-initial", help="Middle initial.")
+    ] = None,
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Create a new user."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        user = client.create_user(
+            email=email,
+            password=password,
+            first_name=first_name,
+            last_name=last_name,
+            role=role,
+            title=title,
+            middle_initial=middle_initial,
+        )
+        if json_output:
+            print_model(user, json_mode=True)
+        else:
+            print_success(f"User {user.email} created.")
+
+
+@app.command("update")
+def update_user(
+    user_id: Annotated[str, typer.Argument(help="User UUID.")],
+    email: Annotated[str | None, typer.Option("--email")] = None,
+    first_name: Annotated[str | None, typer.Option("--first-name")] = None,
+    last_name: Annotated[str | None, typer.Option("--last-name")] = None,
+    role: Annotated[str | None, typer.Option("--role")] = None,
+    title: Annotated[str | None, typer.Option("--title")] = None,
+    middle_initial: Annotated[str | None, typer.Option("--middle-initial")] = None,
+    is_active: Annotated[bool | None, typer.Option("--is-active")] = None,
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Update a user (only provided fields are changed)."""
+    fields: dict[str, object] = {}
+    if email is not None:
+        fields["email"] = email
+    if first_name is not None:
+        fields["first_name"] = first_name
+    if last_name is not None:
+        fields["last_name"] = last_name
+    if role is not None:
+        fields["role"] = role
+    if title is not None:
+        fields["title"] = title
+    if middle_initial is not None:
+        fields["middle_initial"] = middle_initial
+    if is_active is not None:
+        fields["is_active"] = is_active
+
+    if not fields:
+        print_error("No fields to update. Provide at least one option.")
+        raise SystemExit(1)
+
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        user = client.update_user(user_id, **fields)
+        if json_output:
+            print_model(user, json_mode=True)
+        else:
+            print_success(f"User {user.email} updated.")

--- a/cli/opencase_cli/common.py
+++ b/cli/opencase_cli/common.py
@@ -1,0 +1,46 @@
+"""Shared Typer parameter types and client factory."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+from opencase import OpenCaseClient
+
+from opencase_cli.config import load_config
+from opencase_cli.output import print_error
+from opencase_cli.tokens import load_tokens
+
+# Re-usable Annotated types for common CLI options.
+BaseUrlOption = Annotated[
+    str | None,
+    typer.Option("--base-url", envvar="OPENCASE_BASE_URL", help="API base URL."),
+]
+TimeoutOption = Annotated[
+    float | None,
+    typer.Option("--timeout", envvar="OPENCASE_TIMEOUT", help="Timeout in seconds."),
+]
+JsonOption = Annotated[
+    bool,
+    typer.Option("--json", help="Output as JSON."),
+]
+
+
+def get_client(
+    base_url: str | None = None,
+    timeout: float | None = None,
+    *,
+    authenticated: bool = False,
+) -> OpenCaseClient:
+    """Create a configured ``OpenCaseClient``, optionally with stored tokens."""
+    config = load_config(base_url=base_url, timeout=timeout)
+    client = OpenCaseClient(base_url=config.base_url, timeout=config.timeout)
+
+    if authenticated:
+        tokens = load_tokens()
+        if tokens is None:
+            print_error("Not logged in. Run 'opencase login' first.")
+            raise SystemExit(1)
+        client._auth.store_tokens(tokens[0], tokens[1])  # noqa: SLF001
+
+    return client

--- a/cli/opencase_cli/config.py
+++ b/cli/opencase_cli/config.py
@@ -1,0 +1,98 @@
+"""CLI configuration — load/save settings from flags, env, and config file."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+import tomli_w
+
+_DEFAULT_BASE_URL = "http://localhost:8000"
+_DEFAULT_TIMEOUT = 30.0
+
+
+def opencase_dir() -> Path:
+    """Return ``~/.opencase/``, the CLI data directory."""
+    return Path.home() / ".opencase"
+
+
+def config_path() -> Path:
+    """Return the path to the CLI config file."""
+    return opencase_dir() / "config.toml"
+
+
+@dataclass(frozen=True)
+class CLIConfig:
+    """Resolved CLI configuration."""
+
+    base_url: str = _DEFAULT_BASE_URL
+    timeout: float = _DEFAULT_TIMEOUT
+
+
+def load_config(
+    *,
+    base_url: str | None = None,
+    timeout: float | None = None,
+) -> CLIConfig:
+    """Merge config from flags > env vars > config file > defaults.
+
+    Parameters that are ``None`` fall through to the next source.
+    """
+    # Layer 3: config file (lowest precedence)
+    file_base_url: str | None = None
+    file_timeout: float | None = None
+
+    path = config_path()
+    if path.exists():
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+        file_base_url = data.get("base_url")
+        raw_timeout = data.get("timeout")
+        if raw_timeout is not None:
+            file_timeout = float(raw_timeout)
+
+    # Layer 2: env vars
+    env_base_url = os.environ.get("OPENCASE_BASE_URL")
+    env_timeout_raw = os.environ.get("OPENCASE_TIMEOUT")
+    env_timeout = float(env_timeout_raw) if env_timeout_raw else None
+
+    # Merge: flags > env > file > defaults (use is not None, not truthiness)
+    resolved_url = (
+        base_url
+        if base_url is not None
+        else env_base_url
+        if env_base_url is not None
+        else file_base_url
+        if file_base_url is not None
+        else _DEFAULT_BASE_URL
+    )
+    resolved_timeout = (
+        timeout
+        if timeout is not None
+        else env_timeout
+        if env_timeout is not None
+        else file_timeout
+        if file_timeout is not None
+        else _DEFAULT_TIMEOUT
+    )
+
+    return CLIConfig(base_url=resolved_url, timeout=resolved_timeout)
+
+
+def save_config(config: CLIConfig) -> None:
+    """Write configuration to ``~/.opencase/config.toml``."""
+    directory = opencase_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    if sys.platform != "win32":
+        directory.chmod(stat.S_IRWXU)
+
+    path = config_path()
+    data: dict[str, object] = {
+        "base_url": config.base_url,
+        "timeout": config.timeout,
+    }
+    path.write_bytes(tomli_w.dumps(data).encode())

--- a/cli/opencase_cli/main.py
+++ b/cli/opencase_cli/main.py
@@ -1,0 +1,83 @@
+"""OpenCase CLI entry point — Typer application and top-level commands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import opencase
+import typer
+from rich.table import Table
+
+import opencase_cli
+from opencase_cli.commands import auth, firms, health, matters, mfa, users
+from opencase_cli.config import CLIConfig, config_path, load_config, save_config
+from opencase_cli.output import console, print_json, print_success
+
+app = typer.Typer(
+    name="opencase",
+    help="OpenCase CLI — criminal defense discovery platform.",
+    no_args_is_help=True,
+)
+
+# -- register command modules ------------------------------------------------
+
+app.command()(health.health)
+app.command()(health.ready)
+app.command()(auth.login)
+app.command()(auth.logout)
+app.command()(auth.whoami)
+app.add_typer(mfa.app, name="mfa")
+app.add_typer(users.app, name="user")
+app.add_typer(matters.app, name="matter")
+app.add_typer(firms.app, name="firm")
+
+
+# -- top-level commands ------------------------------------------------------
+
+
+@app.command()
+def configure(
+    base_url: Annotated[
+        str | None,
+        typer.Option("--base-url", help="API base URL."),
+    ] = None,
+    timeout: Annotated[
+        float | None,
+        typer.Option("--timeout", help="Request timeout in seconds."),
+    ] = None,
+) -> None:
+    """Configure CLI connection settings (interactive)."""
+    current = load_config()
+
+    if base_url is None:
+        base_url = typer.prompt("Base URL", default=current.base_url)
+    if timeout is None:
+        timeout = float(typer.prompt("Timeout (seconds)", default=current.timeout))
+
+    config = CLIConfig(base_url=base_url, timeout=timeout)
+    save_config(config)
+    print_success(f"Configuration saved to {config_path()}")
+
+
+@app.command()
+def version(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Output as JSON."),
+    ] = False,
+) -> None:
+    """Print CLI and SDK versions."""
+    if json_output:
+        print_json(
+            {
+                "cli_version": opencase_cli.__version__,
+                "sdk_version": opencase.__version__,
+            }
+        )
+    else:
+        table = Table(show_header=False, show_edge=False, pad_edge=False)
+        table.add_column("Component", style="bold")
+        table.add_column("Version")
+        table.add_row("CLI", opencase_cli.__version__)
+        table.add_row("SDK", opencase.__version__)
+        console.print(table)

--- a/cli/opencase_cli/output.py
+++ b/cli/opencase_cli/output.py
@@ -1,0 +1,101 @@
+"""Output formatting — Rich tables, JSON mode, error display."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+
+import httpx
+from opencase import (
+    AuthenticationError,
+    AuthorizationError,
+    OpenCaseError,
+)
+from pydantic import BaseModel
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def print_model(model: BaseModel, *, json_mode: bool) -> None:
+    """Print a Pydantic model as JSON or a Rich key-value table."""
+    if json_mode:
+        console.print(model.model_dump_json(indent=2), highlight=False)
+        return
+
+    data = model.model_dump()
+    table = Table(show_header=False, show_edge=False, pad_edge=False)
+    table.add_column("Field", style="bold")
+    table.add_column("Value")
+    for key, value in data.items():
+        if isinstance(value, dict):
+            for sub_key, sub_val in value.items():
+                table.add_row(f"  {sub_key}", str(sub_val))
+        else:
+            table.add_row(key, str(value))
+    console.print(table)
+
+
+def print_list(
+    models: Sequence[BaseModel],
+    *,
+    columns: list[str],
+    json_mode: bool,
+) -> None:
+    """Print a list of Pydantic models as JSON array or Rich table."""
+    if json_mode:
+        rows = [m.model_dump(mode="json") for m in models]
+        console.print(json.dumps(rows, indent=2, default=str), highlight=False)
+        return
+
+    if not models:
+        console.print("[dim]No results.[/dim]")
+        return
+
+    table = Table(show_edge=False, pad_edge=False)
+    for col in columns:
+        table.add_column(col, style="bold" if col == columns[0] else "")
+    for model in models:
+        data = model.model_dump()
+        table.add_row(*(str(data.get(c, "")) for c in columns))
+    console.print(table)
+
+
+def print_json(data: object) -> None:
+    """Print arbitrary data as formatted JSON."""
+    console.print(json.dumps(data, indent=2, default=str), highlight=False)
+
+
+def print_success(message: str) -> None:
+    """Print a green success message."""
+    console.print(f"[green]{message}[/green]")
+
+
+def print_error(message: str) -> None:
+    """Print a red error message to stderr."""
+    err_console.print(f"[red]{message}[/red]")
+
+
+@contextmanager
+def handle_errors() -> Iterator[None]:
+    """Catch SDK and connection errors, print them, and exit."""
+    try:
+        yield
+    except AuthenticationError as exc:
+        print_error(f"Authentication failed: {exc}")
+        raise SystemExit(1) from None
+    except AuthorizationError as exc:
+        print_error(f"Access denied: {exc}")
+        raise SystemExit(1) from None
+    except OpenCaseError as exc:
+        print_error(f"API error: {exc}")
+        raise SystemExit(1) from None
+    except httpx.ConnectError:
+        print_error("Cannot connect to OpenCase server. Is it running?")
+        raise SystemExit(1) from None
+    except httpx.TimeoutException:
+        print_error("Request timed out. Try increasing --timeout.")
+        raise SystemExit(1) from None

--- a/cli/opencase_cli/tokens.py
+++ b/cli/opencase_cli/tokens.py
@@ -1,0 +1,64 @@
+"""Token persistence — store/load JWT tokens to ``~/.opencase/tokens.json``."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+from opencase_cli.config import opencase_dir
+
+
+def _tokens_path() -> Path:
+    """Return the path to the stored tokens file."""
+    return opencase_dir() / "tokens.json"
+
+
+def save_tokens(access_token: str, refresh_token: str) -> None:
+    """Persist tokens to disk with restricted permissions.
+
+    On Unix, the file is created atomically with 0600 permissions
+    to avoid a window where tokens are world-readable.
+    """
+    path = _tokens_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    content = json.dumps(
+        {"access_token": access_token, "refresh_token": refresh_token}
+    ).encode()
+
+    if sys.platform != "win32":
+        fd = os.open(
+            path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        try:
+            os.write(fd, content)
+        finally:
+            os.close(fd)
+    else:
+        path.write_bytes(content)
+
+
+def load_tokens() -> tuple[str, str] | None:
+    """Load stored tokens. Returns ``(access, refresh)`` or ``None``."""
+    path = _tokens_path()
+    if not path.exists():
+        return None
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    access = data.get("access_token")
+    refresh = data.get("refresh_token")
+    if access and refresh:
+        return (access, refresh)
+    return None
+
+
+def clear_tokens() -> None:
+    """Delete the stored tokens file."""
+    path = _tokens_path()
+    if path.exists():
+        path.unlink()

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,0 +1,73 @@
+[project]
+name = "opencase-cli"
+version = "0.1.0"
+description = "Command-line interface for the OpenCase API"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.12"
+authors = [{ name = "OpenCase Contributors" }]
+
+dependencies = [
+    "opencase-sdk",
+    "opencase-shared",
+    "typer>=0.15",
+    "rich>=13.0",
+    "tomli-w>=1.0",
+]
+
+[project.scripts]
+opencase = "opencase_cli.main:app"
+
+[project.optional-dependencies]
+dev = ["ruff>=0.9", "mypy>=1.14"]
+test = [
+    "pytest>=8.3",
+    "pytest-cov>=6.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["opencase_cli"]
+
+[tool.uv.sources]
+opencase-sdk = { workspace = true }
+opencase-shared = { workspace = true }
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "N",   # pep8-naming
+    "UP",  # pyupgrade
+    "S",   # bandit (security)
+    "B",   # bugbear
+    "SIM", # simplify
+    "T20", # print statements
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "S104", "S105", "S106", "S603", "S607"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["opencase_cli"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+fail_under = 70
+show_missing = true

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,0 +1,177 @@
+"""Shared test fixtures for the CLI test suite."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from shared.models.auth import (
+    MfaRequiredResponse,
+    MfaSetupResponse,
+    MfaStatusResponse,
+    TokenResponse,
+)
+from shared.models.base import MessageResponse
+from shared.models.firm import FirmResponse
+from shared.models.health import HealthResponse, ReadinessResponse, ServiceChecks
+from shared.models.matter import MatterResponse, MatterSummary
+from shared.models.matter_access import MatterAccessResponse
+from shared.models.user import UserResponse, UserSummary
+from typer.testing import CliRunner
+
+from opencase_cli import main as main_module
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def app() -> Any:
+    return main_module.app
+
+
+@pytest.fixture()
+def tmp_opencase_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ~/.opencase/ to a temp directory."""
+    opencase_dir = tmp_path / ".opencase"
+    opencase_dir.mkdir()
+
+    monkeypatch.setattr("opencase_cli.config.opencase_dir", lambda: opencase_dir)
+    monkeypatch.setattr("opencase_cli.tokens.opencase_dir", lambda: opencase_dir)
+    monkeypatch.setattr(
+        "opencase_cli.config.config_path", lambda: opencase_dir / "config.toml"
+    )
+    return opencase_dir
+
+
+def make_jwt(
+    exp: float | None = None,
+    extra: dict[str, object] | None = None,
+) -> str:
+    """Build a fake JWT with the given exp claim (no real signature)."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(
+        b"="
+    )
+    payload: dict[str, object] = {"sub": "user-id"}
+    if exp is not None:
+        payload["exp"] = exp
+    if extra:
+        payload.update(extra)
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=")
+    sig = base64.urlsafe_b64encode(b"fakesig").rstrip(b"=")
+    return f"{header.decode()}.{body.decode()}.{sig.decode()}"
+
+
+@pytest.fixture()
+def stored_tokens(tmp_opencase_dir: Path) -> tuple[str, str]:
+    """Write fake tokens to the temp token file and return them."""
+    from opencase_cli.tokens import save_tokens
+
+    access = make_jwt(exp=time.time() + 3600)
+    refresh = "fake-refresh-token"
+    save_tokens(access, refresh)
+    return (access, refresh)
+
+
+@pytest.fixture()
+def mock_client() -> MagicMock:
+    """Return a MagicMock that quacks like OpenCaseClient."""
+    from opencase import OpenCaseClient
+
+    mock = MagicMock(spec=OpenCaseClient)
+    mock.__enter__ = MagicMock(return_value=mock)
+    mock.__exit__ = MagicMock(return_value=False)
+    return mock
+
+
+# -- pre-built response objects -----------------------------------------------
+
+
+HEALTH_RESPONSE = HealthResponse(status="ok", app="opencase", version="0.1.0")
+
+READINESS_RESPONSE = ReadinessResponse(
+    status="ok", services=ServiceChecks(postgres="ok")
+)
+
+READINESS_DEGRADED = ReadinessResponse(
+    status="degraded", services=ServiceChecks(postgres="error")
+)
+
+TOKEN_RESPONSE = TokenResponse(access_token="access-tok", refresh_token="refresh-tok")
+
+MFA_REQUIRED = MfaRequiredResponse(mfa_required=True, mfa_token="mfa-tok")
+
+MFA_SETUP = MfaSetupResponse(
+    totp_secret="JBSWY3DPEHPK3PXP",
+    provisioning_uri="otpauth://totp/OpenCase:user@firm.com?secret=JBSWY3DPEHPK3PXP",
+)
+
+MFA_ENABLED = MfaStatusResponse(enabled=True)
+MFA_DISABLED = MfaStatusResponse(enabled=False)
+
+LOGOUT_RESPONSE = MessageResponse(detail="Logged out")
+
+USER_SUMMARY = UserSummary(
+    id="00000000-0000-0000-0000-000000000001",
+    email="user@firm.com",
+    first_name="Jane",
+    last_name="Doe",
+    role="attorney",
+    is_active=True,
+)
+
+USER_RESPONSE = UserResponse(
+    id="00000000-0000-0000-0000-000000000001",
+    email="user@firm.com",
+    first_name="Jane",
+    last_name="Doe",
+    role="attorney",
+    is_active=True,
+    title=None,
+    middle_initial=None,
+    totp_enabled=False,
+    firm_id="00000000-0000-0000-0000-000000000002",
+    created_at="2025-01-01T00:00:00",
+    updated_at="2025-01-01T00:00:00",
+)
+
+FIRM_RESPONSE = FirmResponse(
+    id="00000000-0000-0000-0000-000000000002",
+    name="Cora Firm",
+    created_at="2025-01-01T00:00:00",
+)
+
+MATTER_SUMMARY = MatterSummary(
+    id="00000000-0000-0000-0000-000000000010",
+    name="People v. Smith",
+    client_id="00000000-0000-0000-0000-000000000020",
+    status="open",
+    legal_hold=False,
+)
+
+MATTER_RESPONSE = MatterResponse(
+    id="00000000-0000-0000-0000-000000000010",
+    name="People v. Smith",
+    client_id="00000000-0000-0000-0000-000000000020",
+    status="open",
+    legal_hold=False,
+    firm_id="00000000-0000-0000-0000-000000000002",
+    created_at="2025-01-01T00:00:00",
+    updated_at="2025-01-01T00:00:00",
+)
+
+MATTER_ACCESS = MatterAccessResponse(
+    user_id="00000000-0000-0000-0000-000000000001",
+    matter_id="00000000-0000-0000-0000-000000000010",
+    view_work_product=False,
+    assigned_at="2025-01-01T00:00:00",
+)
+
+REVOKE_RESPONSE = MessageResponse(detail="Access revoked")

--- a/cli/tests/test_auth.py
+++ b/cli/tests/test_auth.py
@@ -1,0 +1,142 @@
+"""Tests for login, logout, and whoami commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from opencase import AuthenticationError
+from typer.testing import CliRunner
+
+from opencase_cli.main import app
+from opencase_cli.tokens import load_tokens
+
+from .conftest import (
+    LOGOUT_RESPONSE,
+    MFA_REQUIRED,
+    TOKEN_RESPONSE,
+    USER_RESPONSE,
+)
+
+_PATCH_GET_CLIENT = "opencase_cli.commands.auth.get_client"
+
+
+class TestLogin:
+    def test_login_success(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Path
+    ) -> None:
+        mock_client.login.return_value = TOKEN_RESPONSE
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(
+                app, ["login", "--email", "u@f.com", "--password", "secret"]
+            )
+        assert result.exit_code == 0
+        assert "Logged in" in result.output
+        assert load_tokens() is not None
+
+    def test_login_json(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Path
+    ) -> None:
+        mock_client.login.return_value = TOKEN_RESPONSE
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(
+                app, ["login", "--email", "u@f.com", "--password", "s", "--json"]
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["authenticated"] is True
+
+    def test_login_mfa_flow(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Path
+    ) -> None:
+        mock_client.login.return_value = MFA_REQUIRED
+        mock_client.verify_mfa.return_value = TOKEN_RESPONSE
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                [
+                    "login",
+                    "--email",
+                    "u@f.com",
+                    "--password",
+                    "s",
+                    "--totp-code",
+                    "123456",
+                ],
+            )
+        assert result.exit_code == 0
+        mock_client.verify_mfa.assert_called_once_with(
+            mfa_token="mfa-tok", totp_code="123456"
+        )
+
+    def test_login_invalid_credentials(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Path
+    ) -> None:
+        mock_client.login.side_effect = AuthenticationError(
+            "bad creds", status_code=401
+        )
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(
+                app, ["login", "--email", "u@f.com", "--password", "wrong"]
+            )
+        assert result.exit_code == 1
+
+
+class TestLogout:
+    def test_logout_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.logout.return_value = LOGOUT_RESPONSE
+        with patch("opencase_cli.commands.auth.get_client", return_value=mock_client):
+            result = runner.invoke(app, ["logout"])
+        assert result.exit_code == 0
+        assert "Logged out" in result.output
+        assert load_tokens() is None
+
+    def test_logout_not_logged_in(
+        self, runner: CliRunner, tmp_opencase_dir: Path
+    ) -> None:
+        result = runner.invoke(app, ["logout"])
+        assert result.exit_code == 1
+
+
+class TestWhoami:
+    def test_whoami_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_current_user.return_value = USER_RESPONSE
+        with patch("opencase_cli.commands.auth.get_client", return_value=mock_client):
+            result = runner.invoke(app, ["whoami"])
+        assert result.exit_code == 0
+        assert "user@firm.com" in result.output
+
+    def test_whoami_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_current_user.return_value = USER_RESPONSE
+        with patch("opencase_cli.commands.auth.get_client", return_value=mock_client):
+            result = runner.invoke(app, ["whoami", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["email"] == "user@firm.com"
+        assert data["role"] == "attorney"
+
+    def test_whoami_not_logged_in(
+        self, runner: CliRunner, tmp_opencase_dir: Path
+    ) -> None:
+        result = runner.invoke(app, ["whoami"])
+        assert result.exit_code == 1

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -1,0 +1,97 @@
+"""Tests for CLI configuration loading and saving."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opencase_cli.config import CLIConfig, load_config, save_config
+
+
+class TestLoadConfig:
+    """Config loading precedence: flags > env > file > defaults."""
+
+    def test_defaults(self, tmp_opencase_dir: Path) -> None:
+        config = load_config()
+        assert config.base_url == "http://localhost:8000"
+        assert config.timeout == 30.0
+
+    def test_config_file(self, tmp_opencase_dir: Path) -> None:
+        cfg = CLIConfig(base_url="http://custom:9000", timeout=10.0)
+        save_config(cfg)
+
+        config = load_config()
+        assert config.base_url == "http://custom:9000"
+        assert config.timeout == 10.0
+
+    def test_env_overrides_file(
+        self, tmp_opencase_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        save_config(CLIConfig(base_url="http://file:1000", timeout=5.0))
+        monkeypatch.setenv("OPENCASE_BASE_URL", "http://env:2000")
+        monkeypatch.setenv("OPENCASE_TIMEOUT", "15")
+
+        config = load_config()
+        assert config.base_url == "http://env:2000"
+        assert config.timeout == 15.0
+
+    def test_flags_override_env(
+        self, tmp_opencase_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENCASE_BASE_URL", "http://env:2000")
+        monkeypatch.setenv("OPENCASE_TIMEOUT", "15")
+
+        config = load_config(base_url="http://flag:3000", timeout=99.0)
+        assert config.base_url == "http://flag:3000"
+        assert config.timeout == 99.0
+
+    def test_missing_file_uses_defaults(self, tmp_opencase_dir: Path) -> None:
+        config = load_config()
+        assert config.base_url == "http://localhost:8000"
+
+    @pytest.mark.parametrize(
+        ("flag_url", "env_url", "file_url", "expected"),
+        [
+            ("http://flag", None, None, "http://flag"),
+            (None, "http://env", None, "http://env"),
+            (None, None, "http://file", "http://file"),
+            (None, None, None, "http://localhost:8000"),
+        ],
+    )
+    def test_precedence_chain(
+        self,
+        tmp_opencase_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        flag_url: str | None,
+        env_url: str | None,
+        file_url: str | None,
+        expected: str,
+    ) -> None:
+        if file_url:
+            save_config(CLIConfig(base_url=file_url))
+        if env_url:
+            monkeypatch.setenv("OPENCASE_BASE_URL", env_url)
+
+        config = load_config(base_url=flag_url)
+        assert config.base_url == expected
+
+
+class TestSaveConfig:
+    def test_round_trip(self, tmp_opencase_dir: Path) -> None:
+        original = CLIConfig(base_url="http://test:8080", timeout=42.0)
+        save_config(original)
+        loaded = load_config()
+        assert loaded == original
+
+    def test_creates_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nested = tmp_path / "new" / ".opencase"
+        monkeypatch.setattr("opencase_cli.config.opencase_dir", lambda: nested)
+        monkeypatch.setattr(
+            "opencase_cli.config.config_path", lambda: nested / "config.toml"
+        )
+
+        save_config(CLIConfig())
+        assert (nested / "config.toml").exists()

--- a/cli/tests/test_firms.py
+++ b/cli/tests/test_firms.py
@@ -1,0 +1,49 @@
+"""Tests for firm subcommands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from opencase_cli.main import app
+
+from .conftest import FIRM_RESPONSE
+
+_PATCH = "opencase_cli.commands.firms.get_client"
+
+
+class TestGetFirm:
+    def test_get_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_firm.return_value = FIRM_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["firm", "get"])
+        assert result.exit_code == 0
+        assert "Cora Firm" in result.output
+
+    def test_get_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_firm.return_value = FIRM_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["firm", "get", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["name"] == "Cora Firm"
+
+    def test_not_authenticated(self, runner: CliRunner, tmp_opencase_dir: Path) -> None:
+        result = runner.invoke(app, ["firm", "get"])
+        assert result.exit_code == 1

--- a/cli/tests/test_health.py
+++ b/cli/tests/test_health.py
@@ -1,0 +1,76 @@
+"""Tests for health and ready commands."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from opencase_cli.main import app
+
+from .conftest import HEALTH_RESPONSE, READINESS_DEGRADED, READINESS_RESPONSE
+
+_PATCH_GET_CLIENT = "opencase_cli.commands.health.get_client"
+
+
+class TestHealth:
+    def test_health_success(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Any
+    ) -> None:
+        mock_client.health.return_value = HEALTH_RESPONSE
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["health"])
+        assert result.exit_code == 0
+        assert "ok" in result.output
+
+    def test_health_json(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Any
+    ) -> None:
+        mock_client.health.return_value = HEALTH_RESPONSE
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["health", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+        assert data["app"] == "opencase"
+
+    def test_health_connection_error(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Any
+    ) -> None:
+        import httpx
+
+        mock_client.health.side_effect = httpx.ConnectError("refused")
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["health"])
+        assert result.exit_code == 1
+
+
+class TestReady:
+    def test_ready_success(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Any
+    ) -> None:
+        mock_client.readiness.return_value = READINESS_RESPONSE
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["ready"])
+        assert result.exit_code == 0
+        assert "ok" in result.output
+
+    def test_ready_json(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Any
+    ) -> None:
+        mock_client.readiness.return_value = READINESS_RESPONSE
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["ready", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "ok"
+
+    def test_ready_degraded_exits_1(
+        self, runner: CliRunner, mock_client: Any, tmp_opencase_dir: Any
+    ) -> None:
+        mock_client.readiness.return_value = READINESS_DEGRADED
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["ready"])
+        assert result.exit_code == 1

--- a/cli/tests/test_matters.py
+++ b/cli/tests/test_matters.py
@@ -1,0 +1,195 @@
+"""Tests for matter subcommands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from opencase_cli.main import app
+
+from .conftest import (
+    MATTER_ACCESS,
+    MATTER_RESPONSE,
+    MATTER_SUMMARY,
+    REVOKE_RESPONSE,
+)
+
+_PATCH = "opencase_cli.commands.matters.get_client"
+_MATTER_ID = "00000000-0000-0000-0000-000000000010"
+_USER_ID = "00000000-0000-0000-0000-000000000001"
+
+
+class TestListMatters:
+    def test_list_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.list_matters.return_value = [MATTER_SUMMARY]
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["matter", "list"])
+        assert result.exit_code == 0
+        assert "People v. Smith" in result.output
+
+    def test_list_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.list_matters.return_value = [MATTER_SUMMARY]
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["matter", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["name"] == "People v. Smith"
+
+
+class TestGetMatter:
+    def test_get_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_matter.return_value = MATTER_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["matter", "get", _MATTER_ID])
+        assert result.exit_code == 0
+        assert "People v. Smith" in result.output
+
+    def test_get_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_matter.return_value = MATTER_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["matter", "get", _MATTER_ID, "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "open"
+
+
+class TestCreateMatter:
+    def test_create_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.create_matter.return_value = MATTER_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                [
+                    "matter",
+                    "create",
+                    "--name",
+                    "People v. Jones",
+                    "--client-id",
+                    _USER_ID,
+                ],
+            )
+        assert result.exit_code == 0
+        assert "created" in result.output
+
+
+class TestUpdateMatter:
+    def test_update_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.update_matter.return_value = MATTER_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                ["matter", "update", _MATTER_ID, "--name", "Renamed"],
+            )
+        assert result.exit_code == 0
+        assert "updated" in result.output
+
+    def test_update_no_fields(
+        self,
+        runner: CliRunner,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        result = runner.invoke(app, ["matter", "update", _MATTER_ID])
+        assert result.exit_code == 1
+
+
+class TestMatterAccess:
+    def test_access_list(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.list_matter_access.return_value = [MATTER_ACCESS]
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["matter", "access-list", _MATTER_ID])
+        assert result.exit_code == 0
+        assert "user_id" in result.output
+
+    def test_access_grant(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.grant_matter_access.return_value = MATTER_ACCESS
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                [
+                    "matter",
+                    "access-grant",
+                    _MATTER_ID,
+                    "--user-id",
+                    _USER_ID,
+                ],
+            )
+        assert result.exit_code == 0
+        assert "granted" in result.output
+
+    def test_access_revoke(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.revoke_matter_access.return_value = REVOKE_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                [
+                    "matter",
+                    "access-revoke",
+                    _MATTER_ID,
+                    "--user-id",
+                    _USER_ID,
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_not_authenticated(self, runner: CliRunner, tmp_opencase_dir: Path) -> None:
+        result = runner.invoke(app, ["matter", "list"])
+        assert result.exit_code == 1

--- a/cli/tests/test_mfa.py
+++ b/cli/tests/test_mfa.py
@@ -1,0 +1,119 @@
+"""Tests for MFA subcommands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from opencase_cli.main import app
+
+from .conftest import MFA_DISABLED, MFA_ENABLED, MFA_SETUP
+
+_PATCH_GET_CLIENT = "opencase_cli.commands.mfa.get_client"
+
+
+class TestMfaSetup:
+    def test_setup_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.mfa_setup.return_value = MFA_SETUP
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["mfa", "setup"])
+        assert result.exit_code == 0
+        assert "JBSWY3DPEHPK3PXP" in result.output
+
+    def test_setup_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.mfa_setup.return_value = MFA_SETUP
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["mfa", "setup", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["totp_secret"] == "JBSWY3DPEHPK3PXP"
+
+    def test_setup_not_authenticated(
+        self, runner: CliRunner, tmp_opencase_dir: Path
+    ) -> None:
+        result = runner.invoke(app, ["mfa", "setup"])
+        assert result.exit_code == 1
+
+
+class TestMfaConfirm:
+    def test_confirm_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.mfa_confirm.return_value = MFA_ENABLED
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["mfa", "confirm", "--totp-code", "123456"])
+        assert result.exit_code == 0
+        assert "MFA enabled" in result.output
+
+    def test_confirm_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.mfa_confirm.return_value = MFA_ENABLED
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(
+                app, ["mfa", "confirm", "--totp-code", "123456", "--json"]
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["enabled"] is True
+
+
+class TestMfaDisable:
+    def test_disable_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.mfa_disable.return_value = MFA_DISABLED
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(app, ["mfa", "disable", "--totp-code", "123456"])
+        assert result.exit_code == 0
+        assert "MFA disabled" in result.output
+
+    def test_disable_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.mfa_disable.return_value = MFA_DISABLED
+        with patch(_PATCH_GET_CLIENT, return_value=mock_client):
+            result = runner.invoke(
+                app, ["mfa", "disable", "--totp-code", "123456", "--json"]
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["enabled"] is False
+
+    def test_disable_not_authenticated(
+        self, runner: CliRunner, tmp_opencase_dir: Path
+    ) -> None:
+        result = runner.invoke(app, ["mfa", "disable", "--totp-code", "123456"])
+        assert result.exit_code == 1

--- a/cli/tests/test_tokens.py
+++ b/cli/tests/test_tokens.py
@@ -1,0 +1,42 @@
+"""Tests for token persistence."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from opencase_cli.tokens import clear_tokens, load_tokens, save_tokens
+
+
+class TestTokens:
+    def test_round_trip(self, tmp_opencase_dir: Path) -> None:
+        save_tokens("access-123", "refresh-456")
+        result = load_tokens()
+        assert result == ("access-123", "refresh-456")
+
+    def test_load_missing_returns_none(self, tmp_opencase_dir: Path) -> None:
+        assert load_tokens() is None
+
+    def test_clear_removes_file(self, tmp_opencase_dir: Path) -> None:
+        save_tokens("a", "r")
+        clear_tokens()
+        assert load_tokens() is None
+
+    def test_clear_missing_is_noop(self, tmp_opencase_dir: Path) -> None:
+        clear_tokens()  # should not raise
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="chmod not supported on Windows"
+    )
+    def test_file_permissions(self, tmp_opencase_dir: Path) -> None:
+        save_tokens("a", "r")
+        token_path = tmp_opencase_dir / "tokens.json"
+        mode = token_path.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_load_empty_tokens_returns_none(self, tmp_opencase_dir: Path) -> None:
+        token_path = tmp_opencase_dir / "tokens.json"
+        token_path.write_text('{"access_token": "", "refresh_token": ""}')
+        assert load_tokens() is None

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -1,0 +1,151 @@
+"""Tests for user subcommands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from opencase_cli.main import app
+
+from .conftest import USER_RESPONSE, USER_SUMMARY
+
+_PATCH = "opencase_cli.commands.users.get_client"
+
+
+class TestListUsers:
+    def test_list_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.list_users.return_value = [USER_SUMMARY]
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["user", "list"])
+        assert result.exit_code == 0
+        assert "user@firm.com" in result.output
+
+    def test_list_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.list_users.return_value = [USER_SUMMARY]
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["user", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["email"] == "user@firm.com"
+
+
+class TestGetUser:
+    def test_get_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_user.return_value = USER_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(
+                app, ["user", "get", "00000000-0000-0000-0000-000000000001"]
+            )
+        assert result.exit_code == 0
+        assert "user@firm.com" in result.output
+
+    def test_get_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_user.return_value = USER_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                ["user", "get", "00000000-0000-0000-0000-000000000001", "--json"],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["role"] == "attorney"
+
+
+class TestCreateUser:
+    def test_create_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.create_user.return_value = USER_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                [
+                    "user",
+                    "create",
+                    "--email",
+                    "new@firm.com",
+                    "--password",
+                    "secretpass123",
+                    "--first-name",
+                    "Jane",
+                    "--last-name",
+                    "Doe",
+                    "--role",
+                    "attorney",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "created" in result.output
+
+
+class TestUpdateUser:
+    def test_update_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.update_user.return_value = USER_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                [
+                    "user",
+                    "update",
+                    "00000000-0000-0000-0000-000000000001",
+                    "--first-name",
+                    "Janet",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "updated" in result.output
+
+    def test_update_no_fields(
+        self,
+        runner: CliRunner,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        result = runner.invoke(
+            app,
+            ["user", "update", "00000000-0000-0000-0000-000000000001"],
+        )
+        assert result.exit_code == 1
+
+    def test_not_authenticated(self, runner: CliRunner, tmp_opencase_dir: Path) -> None:
+        result = runner.invoke(app, ["user", "list"])
+        assert result.exit_code == 1

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,134 @@
+# OpenCase CLI Reference
+
+The `opencase` command-line tool is the primary admin and developer
+interface for interacting with a running OpenCase instance.
+
+## Installation
+
+The CLI is part of the uv workspace. From the repository root:
+
+```bash
+uv sync
+```
+
+The `opencase` console script is then available in the virtual
+environment.
+
+## Configuration
+
+### Precedence
+
+Settings resolve in this order (highest wins):
+
+1. CLI flags (`--base-url`, `--timeout`)
+2. Environment variables (`OPENCASE_BASE_URL`, `OPENCASE_TIMEOUT`)
+3. Config file (`~/.opencase/config.toml`)
+4. Defaults (`http://localhost:8000`, 30 s timeout)
+
+### Interactive setup
+
+```bash
+opencase configure
+```
+
+Prompts for base URL and timeout, then writes
+`~/.opencase/config.toml`.
+
+## Commands
+
+### Health checks (unauthenticated)
+
+```bash
+opencase health              # API health status
+opencase ready               # Readiness + service dependency checks
+```
+
+`ready` exits with code 1 if any dependency is degraded.
+
+### Authentication
+
+```bash
+opencase login --email user@firm.com --password secret
+opencase login                                          # interactive prompts
+opencase login --email user@firm.com --password s --totp-code 123456  # MFA
+opencase logout
+opencase whoami              # show current user, role, firm
+```
+
+After login, tokens are stored in `~/.opencase/tokens.json`
+(mode 0600 on Unix). Subsequent commands use them automatically.
+
+### MFA management
+
+```bash
+opencase mfa setup           # shows TOTP secret + provisioning URI
+opencase mfa confirm --totp-code 123456
+opencase mfa disable --totp-code 123456
+```
+
+### Users
+
+```bash
+opencase user list
+opencase user get <user-id>
+opencase user create --email j@firm.com --password secret123! \
+  --first-name Jane --last-name Doe --role attorney
+opencase user update <user-id> --first-name Janet
+```
+
+### Matters
+
+```bash
+opencase matter list
+opencase matter get <matter-id>
+opencase matter create --name "People v. Smith" --client-id <uuid>
+opencase matter update <matter-id> --status closed
+```
+
+### Matter access
+
+```bash
+opencase matter access-list <matter-id>
+opencase matter access-grant <matter-id> --user-id <uuid>
+opencase matter access-grant <matter-id> --user-id <uuid> --view-work-product
+opencase matter access-revoke <matter-id> --user-id <uuid>
+```
+
+### Firm
+
+```bash
+opencase firm get                # show current firm details
+```
+
+### Utility
+
+```bash
+opencase configure           # interactive connection setup
+opencase version             # CLI + SDK versions
+```
+
+## JSON output
+
+All commands support `--json` for machine-readable output:
+
+```bash
+opencase health --json
+opencase whoami --json | jq .email
+```
+
+## Token storage
+
+Tokens are persisted to `~/.opencase/tokens.json` with restricted
+file permissions (0600 on Unix). `opencase logout` clears this file.
+
+On Windows, standard file ACLs apply (chmod is a no-op).
+
+## Global options
+
+Every command accepts:
+
+| Flag | Env var | Description |
+| --- | --- | --- |
+| `--base-url` | `OPENCASE_BASE_URL` | API base URL |
+| `--timeout` | `OPENCASE_TIMEOUT` | Request timeout (seconds) |
+| `--json` | — | Machine-readable JSON output |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -31,15 +31,15 @@
 
 | ID | Feature | Specs | Code | Docs |
 | --- | --- | --- | --- | --- |
-| 2.1 | Redis broker container | Pending | Pending | Pending |
-| 2.2 | Celery app + task definitions (app/workers/) | Pending | Pending | Pending |
-| 2.3 | Celery worker container + Dockerfile | Pending | Pending | Pending |
-| 2.4 | Celery Beat scheduler container | Pending | Pending | Pending |
-| 2.5 | API integration (Celery client, task.delay() submission) | Pending | Pending | Pending |
-| 2.6 | Task status API endpoint (read-only — query task progress/result by task ID for API-triggered tasks) | Pending | Pending | Pending |
-| 2.7 | Observability (Flower container + OTel Celery instrumentation) | Pending | Pending | Pending |
-| 2.8 | Task result persistence (separate Postgres instance, task lifecycle table for audit) | Pending | Pending | Pending |
-| 2.9 | Configuration + env vars (CelerySettings, RedisSettings, FlowerSettings) | Pending | Pending | Pending |
+| 2.1 | Configuration + env vars (CelerySettings, RedisSettings, FlowerSettings) | Pending | Pending | Pending |
+| 2.2 | Redis broker container | Pending | Pending | Pending |
+| 2.3 | Celery app + task definitions (app/workers/) | Pending | Pending | Pending |
+| 2.4 | Task result persistence (separate Postgres instance, task lifecycle table for audit) | Pending | Pending | Pending |
+| 2.5 | Celery worker container + Dockerfile | Pending | Pending | Pending |
+| 2.6 | Celery Beat scheduler container | Pending | Pending | Pending |
+| 2.7 | API integration (Celery client, task.delay() submission) | Pending | Pending | Pending |
+| 2.8 | Task status API endpoint (read-only — query task progress/result by task ID for API-triggered tasks) | Pending | Pending | Pending |
+| 2.9 | Observability (Flower container + OTel Celery instrumentation) | Pending | Pending | Pending |
 
 ## Feature 3 — S3 Storage
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -24,7 +24,7 @@
 | 1.4 | Authentication (JWT, TOTP MFA, login/logout/refresh) | Done | Done | Done |
 | 1.5 | RBAC middleware (role enforcement, `build_qdrant_filter()`) | Done | Done | Done |
 | 1.6 | Python REST client SDK + shared models (sdk/, shared/) | Done | Done | Done |
-| 1.7 | CLI (built on SDK) | Pending | Pending | Pending |
+| 1.7 | CLI (built on SDK) | Done | Done | Done |
 | 1.8 | Core business endpoints (matters, prompt stub, documents stub) | Pending | Pending | Pending |
 
 ## Feature 2 — Worker Queue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.uv.workspace]
-members = ["backend", "shared", "sdk"]
+members = ["backend", "shared", "sdk", "cli"]

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 members = [
     "opencase",
+    "opencase-cli",
     "opencase-sdk",
     "opencase-shared",
 ]
@@ -2044,6 +2045,42 @@ dev = [
 ]
 
 [[package]]
+name = "opencase-cli"
+version = "0.1.0"
+source = { editable = "cli" }
+dependencies = [
+    { name = "opencase-sdk" },
+    { name = "opencase-shared" },
+    { name = "rich" },
+    { name = "tomli-w" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
+    { name = "opencase-sdk", editable = "sdk" },
+    { name = "opencase-shared", editable = "shared" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0" },
+    { name = "rich", specifier = ">=13.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
+    { name = "tomli-w", specifier = ">=1.0" },
+    { name = "typer", specifier = ">=0.15" },
+]
+provides-extras = ["dev", "test"]
+
+[[package]]
 name = "opencase-sdk"
 version = "0.1.0"
 source = { editable = "sdk" }
@@ -3268,6 +3305,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/43/7935f8ea93fcb6680bc10a6fdbf534075c198eeead59150dd5ed68449642/trove_classifiers-2026.1.14.14.tar.gz", hash = "sha256:00492545a1402b09d4858605ba190ea33243d361e2b01c9c296ce06b5c3325f3", size = 16997, upload-time = "2026-01-14T14:54:50.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl", hash = "sha256:1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d", size = 14197, upload-time = "2026-01-14T14:54:49.067Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New `cli/` workspace package (4th uv member) providing the `opencase` command-line tool
- Built on Typer + Rich, consumes `opencase-sdk` for all API calls
- 16 commands across 6 groups: health, auth, mfa, user, matter, firm
- All commands support `--json` for machine-readable output
- Config precedence: CLI flags > env vars > `~/.opencase/config.toml` > defaults
- Token persistence with atomic file writes and 0600 permissions (Unix)
- CI integration: format-lint + unit-tests workflows, pre-commit hooks
- 61 tests, 87% coverage, mypy --strict clean

## Commands

```
opencase health | ready | login | logout | whoami | configure | version
opencase mfa setup | confirm | disable
opencase user list | get | create | update
opencase matter list | get | create | update | access-list | access-grant | access-revoke
opencase firm get
```

## Test plan

- [x] `opencase --help` prints full command tree
- [x] `uv sync` resolves workspace with cli package
- [x] `mypy --strict` passes
- [x] `ruff check` + `ruff format --check` pass
- [x] 61 unit tests pass with 87% coverage (≥70% threshold)
- [x] Pre-commit hooks pass for all cli/ files
- [ ] CI workflows pass on push

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)