### PR TITLE
feat: add document and prompt stub endpoints, SDK, and CLI (Feature 1.8)

### DIFF
--- a/backend/alembic/versions/0003_documents_and_prompts.py
+++ b/backend/alembic/versions/0003_documents_and_prompts.py
@@ -1,0 +1,154 @@
+"""Add documents and prompts tables.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-03-23 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NOW = sa.text("now()")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "documents",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("firm_id", sa.Uuid(), nullable=False),
+        sa.Column("matter_id", sa.Uuid(), nullable=False),
+        sa.Column("filename", sa.String(512), nullable=False),
+        sa.Column(
+            "file_hash",
+            sa.String(64),
+            nullable=False,
+            comment="SHA-256 hex digest for deduplication",
+        ),
+        sa.Column("content_type", sa.String(255), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column(
+            "source",
+            sa.Enum(
+                "government_production",
+                "defense",
+                "court",
+                "work_product",
+                name="document_source",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "classification",
+            sa.Enum(
+                "brady",
+                "giglio",
+                "jencks",
+                "rule16",
+                "work_product",
+                "inculpatory",
+                "unclassified",
+                name="classification",
+            ),
+            nullable=False,
+        ),
+        sa.Column("bates_number", sa.String(100), nullable=True),
+        sa.Column(
+            "legal_hold",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("uploaded_by", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=_NOW,
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=_NOW,
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_documents"),
+        sa.ForeignKeyConstraint(
+            ["firm_id"],
+            ["firms.id"],
+            name="fk_documents_firm_id_firms",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["matter_id"],
+            ["matters.id"],
+            name="fk_documents_matter_id_matters",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["uploaded_by"],
+            ["users.id"],
+            name="fk_documents_uploaded_by_users",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "matter_id", "file_hash", name="uq_documents_matter_id_file_hash"
+        ),
+    )
+    op.create_index("ix_documents_firm_id", "documents", ["firm_id"])
+    op.create_index("ix_documents_matter_id", "documents", ["matter_id"])
+
+    op.create_table(
+        "prompts",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("firm_id", sa.Uuid(), nullable=False),
+        sa.Column("matter_id", sa.Uuid(), nullable=False),
+        sa.Column("query", sa.Text(), nullable=False),
+        sa.Column("response", sa.Text(), nullable=True),
+        sa.Column("created_by", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=_NOW,
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=_NOW,
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_prompts"),
+        sa.ForeignKeyConstraint(
+            ["firm_id"],
+            ["firms.id"],
+            name="fk_prompts_firm_id_firms",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["matter_id"],
+            ["matters.id"],
+            name="fk_prompts_matter_id_matters",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by"],
+            ["users.id"],
+            name="fk_prompts_created_by_users",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index("ix_prompts_firm_id", "prompts", ["firm_id"])
+    op.create_index("ix_prompts_matter_id", "prompts", ["matter_id"])
+
+
+def downgrade() -> None:
+    pass  # fix-forward — never roll back schema changes

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -1,0 +1,118 @@
+"""Document router — stub endpoints for document management."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from opentelemetry import trace
+from shared.models.document import (
+    CreateDocumentRequest,
+    DocumentResponse,
+    DocumentSummary,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user
+from app.core.metrics import documents_created
+from app.db import get_db
+from app.db.models.user import User
+
+tracer = trace.get_tracer(__name__)
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _stub_document_response(
+    doc_id: uuid.UUID,
+    body: CreateDocumentRequest,
+    user: User,
+) -> DocumentResponse:
+    now = datetime.now(UTC)
+    return DocumentResponse(
+        id=doc_id,
+        firm_id=user.firm_id,
+        matter_id=body.matter_id,
+        filename=body.filename,
+        content_type=body.content_type,
+        size_bytes=body.size_bytes,
+        source=body.source,
+        classification=body.classification,
+        legal_hold=False,
+        file_hash=body.file_hash,
+        bates_number=body.bates_number,
+        uploaded_by=user.id,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /documents/
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/",
+    response_model=DocumentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_document(
+    body: CreateDocumentRequest,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> DocumentResponse:
+    """Stub — accepts document metadata and returns a canned response.
+
+    Future: will compute SHA-256, store file in MinIO, and save metadata.
+    """
+    with tracer.start_as_current_span(
+        "documents.create",
+        attributes={"user.id": str(user.id), "matter.id": str(body.matter_id)},
+    ):
+        doc_id = uuid.uuid4()
+        documents_created.add(1)
+        return _stub_document_response(doc_id, body, user)
+
+
+# ---------------------------------------------------------------------------
+# GET /documents/
+# ---------------------------------------------------------------------------
+
+
+@router.get("/", response_model=list[DocumentSummary])
+async def list_documents(
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> list[DocumentSummary]:
+    """Stub — returns an empty list."""
+    with tracer.start_as_current_span(
+        "documents.list",
+        attributes={"user.id": str(user.id)},
+    ):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# GET /documents/{document_id}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{document_id}", response_model=DocumentResponse, responses={404: {}})
+async def get_document(
+    document_id: uuid.UUID,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> DocumentResponse:
+    """Stub — always returns 404."""
+    with tracer.start_as_current_span(
+        "documents.get",
+        attributes={"user.id": str(user.id), "document.id": str(document_id)},
+    ):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/backend/app/api/prompts.py
+++ b/backend/app/api/prompts.py
@@ -1,0 +1,106 @@
+"""Prompt router — stub endpoints for AI chatbot prompts."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from opentelemetry import trace
+from shared.models.prompt import (
+    CreatePromptRequest,
+    PromptResponse,
+    PromptSummary,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user
+from app.core.metrics import prompts_created
+from app.db import get_db
+from app.db.models.user import User
+
+tracer = trace.get_tracer(__name__)
+
+router = APIRouter(prefix="/prompts", tags=["prompts"])
+
+_STUB_RESPONSE = (
+    "This is a stub response. RAG integration is not yet implemented. "
+    "In the future, this endpoint will perform a matter-scoped vector search "
+    "and return a cited answer from your case documents."
+)
+
+
+# ---------------------------------------------------------------------------
+# POST /prompts/
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/",
+    response_model=PromptResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_prompt(
+    body: CreatePromptRequest,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> PromptResponse:
+    """Stub — accepts a prompt and returns a canned response.
+
+    Future: will trigger a matter-scoped RAG query against Qdrant and return
+    a cited answer.
+    """
+    with tracer.start_as_current_span(
+        "prompts.create",
+        attributes={"user.id": str(user.id), "matter.id": str(body.matter_id)},
+    ):
+        now = datetime.now(UTC)
+        prompt_id = uuid.uuid4()
+        prompts_created.add(1)
+        return PromptResponse(
+            id=prompt_id,
+            firm_id=user.firm_id,
+            matter_id=body.matter_id,
+            query=body.query,
+            response=_STUB_RESPONSE,
+            created_by=user.id,
+            created_at=now,
+            updated_at=now,
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET /prompts/
+# ---------------------------------------------------------------------------
+
+
+@router.get("/", response_model=list[PromptSummary])
+async def list_prompts(
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> list[PromptSummary]:
+    """Stub — returns an empty list."""
+    with tracer.start_as_current_span(
+        "prompts.list",
+        attributes={"user.id": str(user.id)},
+    ):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# GET /prompts/{prompt_id}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{prompt_id}", response_model=PromptResponse, responses={404: {}})
+async def get_prompt(
+    prompt_id: uuid.UUID,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> PromptResponse:
+    """Stub — always returns 404."""
+    with tracer.start_as_current_span(
+        "prompts.get",
+        attributes={"user.id": str(user.id), "prompt.id": str(prompt_id)},
+    ):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -76,3 +76,21 @@ matter_access_revoked = meter.create_counter(
     "opencase.matter_access.revoked",
     description="Matter access revocations",
 )
+
+# ---------------------------------------------------------------------------
+# Documents (Feature 1.8)
+# ---------------------------------------------------------------------------
+
+documents_created = meter.create_counter(
+    "opencase.documents.created",
+    description="Documents created",
+)
+
+# ---------------------------------------------------------------------------
+# Prompts (Feature 1.8)
+# ---------------------------------------------------------------------------
+
+prompts_created = meter.create_counter(
+    "opencase.prompts.created",
+    description="Prompts submitted",
+)

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -1,9 +1,19 @@
 """DB models — import all models here so Alembic can discover them via Base.metadata."""
 
+from app.db.models.document import Document
 from app.db.models.firm import Firm
 from app.db.models.matter import Matter
 from app.db.models.matter_access import MatterAccess
+from app.db.models.prompt import Prompt
 from app.db.models.refresh_token import RefreshToken
 from app.db.models.user import User
 
-__all__ = ["Firm", "Matter", "MatterAccess", "RefreshToken", "User"]
+__all__ = [
+    "Document",
+    "Firm",
+    "Matter",
+    "MatterAccess",
+    "Prompt",
+    "RefreshToken",
+    "User",
+]

--- a/backend/app/db/models/document.py
+++ b/backend/app/db/models/document.py
@@ -1,0 +1,81 @@
+"""Document model — one row per uploaded document within a matter."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from shared.models.enums import Classification, DocumentSource
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+if TYPE_CHECKING:
+    from app.db.models.firm import Firm
+    from app.db.models.matter import Matter
+    from app.db.models.user import User
+
+
+class Document(Base):
+    __tablename__ = "documents"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    firm_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("firms.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    matter_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    filename: Mapped[str] = mapped_column(String(512), nullable=False)
+    file_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, comment="SHA-256 hex digest for deduplication"
+    )
+    content_type: Mapped[str] = mapped_column(String(255), nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    source: Mapped[DocumentSource] = mapped_column(
+        Enum(DocumentSource, name="document_source"),
+        nullable=False,
+        default=DocumentSource.defense,
+    )
+    classification: Mapped[Classification] = mapped_column(
+        Enum(Classification, name="classification"),
+        nullable=False,
+        default=Classification.unclassified,
+    )
+    bates_number: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    legal_hold: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    uploaded_by: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    firm: Mapped[Firm] = relationship()
+    matter: Mapped[Matter] = relationship()
+    uploader: Mapped[User] = relationship()
+
+    # Same file (by hash) within the same matter is a duplicate
+    __table_args__ = (
+        UniqueConstraint(
+            "matter_id", "file_hash", name="uq_documents_matter_id_file_hash"
+        ),
+    )

--- a/backend/app/db/models/prompt.py
+++ b/backend/app/db/models/prompt.py
@@ -1,0 +1,48 @@
+"""Prompt model — one row per user query submitted to the AI chatbot."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+if TYPE_CHECKING:
+    from app.db.models.firm import Firm
+    from app.db.models.matter import Matter
+    from app.db.models.user import User
+
+
+class Prompt(Base):
+    __tablename__ = "prompts"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    firm_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("firms.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    matter_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    query: Mapped[str] = mapped_column(Text, nullable=False)
+    response: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    firm: Mapped[Firm] = relationship()
+    matter: Mapped[Matter] = relationship()
+    creator: Mapped[User] = relationship()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,10 +13,12 @@ from contextlib import asynccontextmanager  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 
 from app.api.auth import router as auth_router  # noqa: E402
+from app.api.documents import router as documents_router  # noqa: E402
 from app.api.firms import router as firms_router  # noqa: E402
 from app.api.health import router as health_router  # noqa: E402
 from app.api.matter_access import router as matter_access_router  # noqa: E402
 from app.api.matters import router as matters_router  # noqa: E402
+from app.api.prompts import router as prompts_router  # noqa: E402
 from app.api.users import router as users_router  # noqa: E402
 from app.core.telemetry import configure_instrumentation, setup_telemetry  # noqa: E402
 
@@ -69,5 +71,7 @@ app.include_router(firms_router)
 app.include_router(users_router)
 app.include_router(matters_router)
 app.include_router(matter_access_router)
+app.include_router(documents_router)
+app.include_router(prompts_router)
 
 configure_instrumentation(app, settings)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,14 +11,23 @@ from dotenv import load_dotenv
 _ENV_TEST = Path(__file__).parent.parent / ".env.test"
 load_dotenv(_ENV_TEST)
 
+from collections.abc import AsyncGenerator, AsyncIterator  # noqa: E402
+from contextlib import asynccontextmanager  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
 import pytest  # noqa: E402
 from httpx import ASGITransport, AsyncClient  # noqa: E402
 from shared.models.enums import Role  # noqa: E402
 from sqlalchemy import create_engine, delete  # noqa: E402
 from sqlalchemy.orm import Session  # noqa: E402
 
-from app.core.auth import hash_password  # noqa: E402
+from app.core.auth import (  # noqa: E402
+    create_access_token,
+    get_current_user,
+    hash_password,
+)
 from app.core.config import settings  # noqa: E402
+from app.db import get_db  # noqa: E402
 from app.db.models.firm import Firm  # noqa: E402
 from app.db.models.matter import Matter  # noqa: E402
 from app.db.models.matter_access import MatterAccess  # noqa: E402
@@ -44,6 +53,91 @@ async def client() -> AsyncClient:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
+
+
+# ---------------------------------------------------------------------------
+# FakeSession — in-memory async session stand-in for unit tests
+# ---------------------------------------------------------------------------
+
+
+class FakeSession:
+    """Async session stand-in with configurable query results.
+
+    Queue results with ``add_result()`` (single) or ``add_results_list()``
+    (list).  Each call to ``execute()`` pops the next queued result.
+    """
+
+    def __init__(self) -> None:
+        self._results: list[object] = []
+        self._call_idx = 0
+        self.committed = False
+        self._added: list[object] = []
+        self._deleted: list[object] = []
+
+    def add_result(self, obj: object) -> None:
+        self._results.append(obj)
+
+    def add_results_list(self, objs: list[object]) -> None:
+        self._results.append(objs)
+
+    async def execute(self, stmt: object) -> MagicMock:
+        result = MagicMock()
+        if self._call_idx < len(self._results):
+            val = self._results[self._call_idx]
+            self._call_idx += 1
+            if isinstance(val, list):
+                result.scalars.return_value.all.return_value = val
+                result.scalar_one_or_none.return_value = val[0] if val else None
+            else:
+                result.scalar_one_or_none.return_value = val
+                result.scalars.return_value.all.return_value = (
+                    [val] if val is not None else []
+                )
+        else:
+            result.scalar_one_or_none.return_value = None
+            result.scalars.return_value.all.return_value = []
+        return result
+
+    def add(self, obj: object) -> None:
+        self._added.append(obj)
+
+    async def delete(self, obj: object) -> None:
+        self._deleted.append(obj)
+
+    async def commit(self) -> None:
+        self.committed = True
+
+    async def rollback(self) -> None:
+        pass
+
+    async def refresh(self, obj: object) -> None:
+        pass
+
+
+@asynccontextmanager
+async def api_client(user: User, fake: FakeSession) -> AsyncIterator[AsyncClient]:
+    """Set up dependency overrides and yield an authenticated AsyncClient."""
+
+    async def _get_db() -> AsyncGenerator[FakeSession, None]:
+        yield fake
+
+    async def _get_current_user() -> User:
+        return user
+
+    app.dependency_overrides[get_db] = _get_db
+    app.dependency_overrides[get_current_user] = _get_current_user
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+def auth_header(user: User) -> dict[str, str]:
+    """Return an Authorization header dict for the given user."""
+    token = create_access_token(user)
+    return {"Authorization": f"Bearer {token}"}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_document_prompt_endpoints.py
+++ b/backend/tests/test_document_prompt_endpoints.py
@@ -1,0 +1,189 @@
+"""Unit tests for document and prompt stub API endpoints.
+
+Uses AsyncClient + in-memory overrides via shared FakeSession / api_client
+from conftest.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from shared.models.enums import Role
+
+from tests.conftest import FakeSession, api_client, auth_header
+from tests.factories import make_user
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_FIRM_ID = uuid.uuid4()
+_VALID_HASH = "a" * 64  # 64-char hex string (SHA-256)
+
+
+# ---------------------------------------------------------------------------
+# POST /documents/
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDocument:
+    @pytest.mark.asyncio
+    async def test_stub_returns_201(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            resp = await ac.post(
+                "/documents/",
+                json={
+                    "matter_id": str(uuid.uuid4()),
+                    "filename": "evidence.pdf",
+                    "content_type": "application/pdf",
+                    "size_bytes": 1024,
+                    "file_hash": _VALID_HASH,
+                    "source": "government_production",
+                    "classification": "brady",
+                },
+                headers=auth_header(user),
+            )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["filename"] == "evidence.pdf"
+        assert data["source"] == "government_production"
+        assert data["classification"] == "brady"
+        assert data["file_hash"] == _VALID_HASH
+        assert data["firm_id"] == str(user.firm_id)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("filename", ""),
+            ("content_type", ""),
+            ("size_bytes", -1),
+            ("file_hash", "tooshort"),
+        ],
+    )
+    async def test_validation_rejects_bad_input(
+        self, field: str, value: object
+    ) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        payload = {
+            "matter_id": str(uuid.uuid4()),
+            "filename": "evidence.pdf",
+            "content_type": "application/pdf",
+            "size_bytes": 1024,
+            "file_hash": _VALID_HASH,
+        }
+        payload[field] = value
+        async with api_client(user, fake) as ac:
+            resp = await ac.post(
+                "/documents/",
+                json=payload,
+                headers=auth_header(user),
+            )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /documents/
+# ---------------------------------------------------------------------------
+
+
+class TestListDocuments:
+    @pytest.mark.asyncio
+    async def test_stub_returns_empty_list(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            resp = await ac.get("/documents/", headers=auth_header(user))
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /documents/{document_id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetDocument:
+    @pytest.mark.asyncio
+    async def test_stub_returns_404(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(f"/documents/{uuid.uuid4()}", headers=auth_header(user))
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /prompts/
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePrompt:
+    @pytest.mark.asyncio
+    async def test_stub_returns_201_with_canned_response(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            resp = await ac.post(
+                "/prompts/",
+                json={
+                    "matter_id": str(uuid.uuid4()),
+                    "query": "What Brady material exists?",
+                },
+                headers=auth_header(user),
+            )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["query"] == "What Brady material exists?"
+        assert "stub" in data["response"].lower()
+        assert data["firm_id"] == str(user.firm_id)
+
+    @pytest.mark.asyncio
+    async def test_validation_rejects_empty_query(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            resp = await ac.post(
+                "/prompts/",
+                json={
+                    "matter_id": str(uuid.uuid4()),
+                    "query": "",
+                },
+                headers=auth_header(user),
+            )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /prompts/
+# ---------------------------------------------------------------------------
+
+
+class TestListPrompts:
+    @pytest.mark.asyncio
+    async def test_stub_returns_empty_list(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            resp = await ac.get("/prompts/", headers=auth_header(user))
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /prompts/{prompt_id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrompt:
+    @pytest.mark.asyncio
+    async def test_stub_returns_404(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(f"/prompts/{uuid.uuid4()}", headers=auth_header(user))
+        assert resp.status_code == 404

--- a/backend/tests/test_entity_endpoints.py
+++ b/backend/tests/test_entity_endpoints.py
@@ -1,25 +1,18 @@
 """Unit tests for firm, user, matter, and matter_access API endpoints.
 
-Uses AsyncClient + in-memory overrides following the pattern in
-test_auth_endpoints.py.
+Uses AsyncClient + in-memory overrides via shared FakeSession / api_client
+from conftest.py.
 """
 
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator
-from contextlib import asynccontextmanager
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
 
 import pytest
-from httpx import ASGITransport, AsyncClient
 from shared.models.enums import Role
 
-from app.core.auth import create_access_token, get_current_user
-from app.db import get_db
-from app.db.models.user import User
-from app.main import app
+from tests.conftest import FakeSession, api_client, auth_header
 from tests.factories import make_firm, make_matter, make_matter_access, make_user
 
 # ---------------------------------------------------------------------------
@@ -28,81 +21,6 @@ from tests.factories import make_firm, make_matter, make_matter_access, make_use
 
 _FIRM_ID = uuid.uuid4()
 _NOW = datetime.now(UTC)
-
-
-class FakeSession:
-    """Async session stand-in with configurable query results."""
-
-    def __init__(self) -> None:
-        self._results: list[object] = []
-        self._call_idx = 0
-        self.committed = False
-        self._added: list[object] = []
-        self._deleted: list[object] = []
-
-    def add_result(self, obj: object) -> None:
-        self._results.append(obj)
-
-    def add_results_list(self, objs: list[object]) -> None:
-        self._results.append(objs)
-
-    async def execute(self, stmt: object) -> MagicMock:
-        result = MagicMock()
-        if self._call_idx < len(self._results):
-            val = self._results[self._call_idx]
-            self._call_idx += 1
-            if isinstance(val, list):
-                result.scalars.return_value.all.return_value = val
-                result.scalar_one_or_none.return_value = val[0] if val else None
-            else:
-                result.scalar_one_or_none.return_value = val
-                result.scalars.return_value.all.return_value = (
-                    [val] if val is not None else []
-                )
-        else:
-            result.scalar_one_or_none.return_value = None
-            result.scalars.return_value.all.return_value = []
-        return result
-
-    def add(self, obj: object) -> None:
-        self._added.append(obj)
-
-    async def delete(self, obj: object) -> None:
-        self._deleted.append(obj)
-
-    async def commit(self) -> None:
-        self.committed = True
-
-    async def rollback(self) -> None:
-        pass
-
-    async def refresh(self, obj: object) -> None:
-        pass
-
-
-@asynccontextmanager
-async def api_client(user: User, fake: FakeSession) -> AsyncIterator[AsyncClient]:
-    """Set up dependency overrides and yield an authenticated AsyncClient."""
-
-    async def _get_db() -> AsyncGenerator[FakeSession, None]:
-        yield fake
-
-    async def _get_current_user() -> User:
-        return user
-
-    app.dependency_overrides[get_db] = _get_db
-    app.dependency_overrides[get_current_user] = _get_current_user
-    try:
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            yield ac
-    finally:
-        app.dependency_overrides.clear()
-
-
-def _auth_header(user: User) -> dict[str, str]:
-    token = create_access_token(user)
-    return {"Authorization": f"Bearer {token}"}
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +36,7 @@ class TestGetFirm:
         fake = FakeSession()
         fake.add_result(firm)
         async with api_client(user, fake) as ac:
-            resp = await ac.get("/firms/me", headers=_auth_header(user))
+            resp = await ac.get("/firms/me", headers=auth_header(user))
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "Cora Firm"
@@ -135,7 +53,7 @@ class TestGetCurrentUser:
         user = make_user(firm_id=_FIRM_ID, role=Role.admin)
         fake = FakeSession()
         async with api_client(user, fake) as ac:
-            resp = await ac.get("/users/me", headers=_auth_header(user))
+            resp = await ac.get("/users/me", headers=auth_header(user))
         assert resp.status_code == 200
         data = resp.json()
         assert data["email"] == user.email
@@ -157,7 +75,7 @@ class TestListUsers:
         fake = FakeSession()
         fake.add_results_list([user, other])
         async with api_client(user, fake) as ac:
-            resp = await ac.get("/users/", headers=_auth_header(user))
+            resp = await ac.get("/users/", headers=auth_header(user))
         assert resp.status_code == 200
         assert len(resp.json()) == 2  # noqa: PLR2004
 
@@ -166,7 +84,7 @@ class TestListUsers:
         user = make_user(firm_id=_FIRM_ID, role=Role.investigator)
         fake = FakeSession()
         async with api_client(user, fake) as ac:
-            resp = await ac.get("/users/", headers=_auth_header(user))
+            resp = await ac.get("/users/", headers=auth_header(user))
         assert resp.status_code == 403
 
 
@@ -183,7 +101,7 @@ class TestGetUser:
         fake = FakeSession()
         fake.add_result(target)
         async with api_client(user, fake) as ac:
-            resp = await ac.get(f"/users/{target.id}", headers=_auth_header(user))
+            resp = await ac.get(f"/users/{target.id}", headers=auth_header(user))
         assert resp.status_code == 200
         assert resp.json()["id"] == str(target.id)
 
@@ -193,7 +111,7 @@ class TestGetUser:
         fake = FakeSession()
         fake.add_result(None)  # not found in firm
         async with api_client(user, fake) as ac:
-            resp = await ac.get(f"/users/{uuid.uuid4()}", headers=_auth_header(user))
+            resp = await ac.get(f"/users/{uuid.uuid4()}", headers=auth_header(user))
         assert resp.status_code == 404
 
 
@@ -217,7 +135,7 @@ class TestCreateUser:
                     "last_name": "User",
                     "role": "paralegal",
                 },
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 201
 
@@ -235,7 +153,7 @@ class TestCreateUser:
                     "last_name": "User",
                     "role": "paralegal",
                 },
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 403
 
@@ -256,7 +174,7 @@ class TestUpdateUser:
             resp = await ac.patch(
                 f"/users/{target.id}",
                 json={"first_name": "Updated"},
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 200
 
@@ -269,7 +187,7 @@ class TestUpdateUser:
             resp = await ac.patch(
                 f"/users/{user.id}",
                 json={"is_active": False},
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 400
         assert "Cannot deactivate your own account" in resp.json()["detail"]
@@ -283,7 +201,7 @@ class TestUpdateUser:
             resp = await ac.patch(
                 f"/users/{uuid.uuid4()}",
                 json={"first_name": "Updated"},
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 404
 
@@ -302,7 +220,7 @@ class TestListMatters:
         fake = FakeSession()
         fake.add_results_list([m1, m2])
         async with api_client(user, fake) as ac:
-            resp = await ac.get("/matters/", headers=_auth_header(user))
+            resp = await ac.get("/matters/", headers=auth_header(user))
         assert resp.status_code == 200
         assert len(resp.json()) == 2  # noqa: PLR2004
 
@@ -320,7 +238,7 @@ class TestGetMatter:
         fake = FakeSession()
         fake.add_result(matter)
         async with api_client(user, fake) as ac:
-            resp = await ac.get(f"/matters/{matter.id}", headers=_auth_header(user))
+            resp = await ac.get(f"/matters/{matter.id}", headers=auth_header(user))
         assert resp.status_code == 200
         assert resp.json()["name"] == matter.name
 
@@ -330,7 +248,7 @@ class TestGetMatter:
         fake = FakeSession()
         fake.add_result(None)
         async with api_client(user, fake) as ac:
-            resp = await ac.get(f"/matters/{uuid.uuid4()}", headers=_auth_header(user))
+            resp = await ac.get(f"/matters/{uuid.uuid4()}", headers=auth_header(user))
         assert resp.status_code == 404
 
 
@@ -348,7 +266,7 @@ class TestCreateMatter:
             resp = await ac.post(
                 "/matters/",
                 json={"name": "People v. Smith", "client_id": str(uuid.uuid4())},
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 201
 
@@ -360,7 +278,7 @@ class TestCreateMatter:
             resp = await ac.post(
                 "/matters/",
                 json={"name": "Test", "client_id": str(uuid.uuid4())},
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 403
 
@@ -381,7 +299,7 @@ class TestUpdateMatter:
             resp = await ac.patch(
                 f"/matters/{matter.id}",
                 json={"status": "closed"},
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 200
 
@@ -402,7 +320,7 @@ class TestListMatterAccess:
         fake.add_results_list([access])  # list query
         async with api_client(user, fake) as ac:
             resp = await ac.get(
-                f"/matters/{matter.id}/access", headers=_auth_header(user)
+                f"/matters/{matter.id}/access", headers=auth_header(user)
             )
         assert resp.status_code == 200
         assert len(resp.json()) == 1
@@ -413,7 +331,7 @@ class TestListMatterAccess:
         fake = FakeSession()
         async with api_client(user, fake) as ac:
             resp = await ac.get(
-                f"/matters/{uuid.uuid4()}/access", headers=_auth_header(user)
+                f"/matters/{uuid.uuid4()}/access", headers=auth_header(user)
             )
         assert resp.status_code == 403
 
@@ -436,7 +354,7 @@ class TestGrantMatterAccess:
             resp = await ac.post(
                 f"/matters/{matter.id}/access",
                 json={"user_id": str(target.id), "view_work_product": False},
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 201
 
@@ -459,7 +377,7 @@ class TestRevokeMatterAccess:
         async with api_client(user, fake) as ac:
             resp = await ac.delete(
                 f"/matters/{matter.id}/access/{target.id}",
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 200
         assert resp.json()["detail"] == "Access revoked"
@@ -474,6 +392,6 @@ class TestRevokeMatterAccess:
         async with api_client(user, fake) as ac:
             resp = await ac.delete(
                 f"/matters/{matter.id}/access/{uuid.uuid4()}",
-                headers=_auth_header(user),
+                headers=auth_header(user),
             )
         assert resp.status_code == 404

--- a/cli/opencase_cli/commands/documents.py
+++ b/cli/opencase_cli/commands/documents.py
@@ -1,0 +1,96 @@
+"""Document management subcommands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
+from opencase_cli.output import (
+    handle_errors,
+    print_list,
+    print_model,
+    print_success,
+)
+
+app = typer.Typer(help="Document management.", no_args_is_help=True)
+
+_DOCUMENT_COLUMNS = [
+    "id",
+    "filename",
+    "content_type",
+    "source",
+    "classification",
+    "matter_id",
+]
+
+
+@app.command("list")
+def list_documents(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """List all documents."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_list(
+            client.list_documents(),
+            columns=_DOCUMENT_COLUMNS,
+            json_mode=json_output,
+        )
+
+
+@app.command("get")
+def get_document(
+    document_id: Annotated[str, typer.Argument(help="Document UUID.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Get a document by ID."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_model(client.get_document(document_id), json_mode=json_output)
+
+
+@app.command("upload")
+def upload_document(
+    matter_id: Annotated[str, typer.Option("--matter-id", help="Matter UUID.")],
+    filename: Annotated[str, typer.Option("--filename", help="Original filename.")],
+    content_type: Annotated[str, typer.Option("--content-type", help="MIME type.")],
+    size_bytes: Annotated[
+        int, typer.Option("--size-bytes", help="File size in bytes.")
+    ],
+    file_hash: Annotated[str, typer.Option("--file-hash", help="SHA-256 hex digest.")],
+    source: Annotated[
+        str, typer.Option("--source", help="Document source.")
+    ] = "defense",
+    classification: Annotated[
+        str, typer.Option("--classification", help="Document classification.")
+    ] = "unclassified",
+    bates_number: Annotated[
+        str | None, typer.Option("--bates-number", help="Bates number.")
+    ] = None,
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Upload a document (stub)."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        doc = client.upload_document(
+            matter_id=matter_id,
+            filename=filename,
+            content_type=content_type,
+            size_bytes=size_bytes,
+            file_hash=file_hash,
+            source=source,
+            classification=classification,
+            bates_number=bates_number,
+        )
+        if json_output:
+            print_model(doc, json_mode=True)
+        else:
+            print_success(f"Document '{doc.filename}' uploaded.")

--- a/cli/opencase_cli/commands/prompts.py
+++ b/cli/opencase_cli/commands/prompts.py
@@ -1,0 +1,66 @@
+"""Prompt management subcommands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
+from opencase_cli.output import (
+    handle_errors,
+    print_list,
+    print_model,
+    print_success,
+)
+
+app = typer.Typer(help="AI prompt management.", no_args_is_help=True)
+
+_PROMPT_COLUMNS = ["id", "matter_id", "query", "created_at"]
+
+
+@app.command("list")
+def list_prompts(
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """List all prompts."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_list(
+            client.list_prompts(),
+            columns=_PROMPT_COLUMNS,
+            json_mode=json_output,
+        )
+
+
+@app.command("get")
+def get_prompt(
+    prompt_id: Annotated[str, typer.Argument(help="Prompt UUID.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Get a prompt by ID."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_model(client.get_prompt(prompt_id), json_mode=json_output)
+
+
+@app.command("submit")
+def submit_prompt(
+    matter_id: Annotated[str, typer.Option("--matter-id", help="Matter UUID.")],
+    query: Annotated[str, typer.Argument(help="Query text.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Submit a prompt to the AI chatbot (stub)."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        prompt = client.submit_prompt(matter_id=matter_id, query=query)
+        if json_output:
+            print_model(prompt, json_mode=True)
+        else:
+            print_success(f"Prompt submitted. Response: {prompt.response}")

--- a/cli/opencase_cli/main.py
+++ b/cli/opencase_cli/main.py
@@ -9,7 +9,16 @@ import typer
 from rich.table import Table
 
 import opencase_cli
-from opencase_cli.commands import auth, firms, health, matters, mfa, users
+from opencase_cli.commands import (
+    auth,
+    documents,
+    firms,
+    health,
+    matters,
+    mfa,
+    prompts,
+    users,
+)
 from opencase_cli.config import CLIConfig, config_path, load_config, save_config
 from opencase_cli.output import console, print_json, print_success
 
@@ -29,6 +38,8 @@ app.command()(auth.whoami)
 app.add_typer(mfa.app, name="mfa")
 app.add_typer(users.app, name="user")
 app.add_typer(matters.app, name="matter")
+app.add_typer(documents.app, name="document")
+app.add_typer(prompts.app, name="prompt")
 app.add_typer(firms.app, name="firm")
 
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -94,6 +94,34 @@ opencase matter access-grant <matter-id> --user-id <uuid> --view-work-product
 opencase matter access-revoke <matter-id> --user-id <uuid>
 ```
 
+### Documents (stub)
+
+```bash
+opencase document list
+opencase document get <document-id>
+opencase document upload --matter-id <uuid> --filename evidence.pdf \
+  --content-type application/pdf --size-bytes 1024 \
+  --file-hash <sha256-hex>
+opencase document upload --matter-id <uuid> --filename report.pdf \
+  --content-type application/pdf --size-bytes 2048 \
+  --file-hash <sha256-hex> --source government_production \
+  --classification brady --bates-number GOV-001
+```
+
+All document endpoints return stub responses. Real upload
+(MinIO storage, SHA-256 computation) will be added in Feature 6.
+
+### Prompts (stub)
+
+```bash
+opencase prompt list
+opencase prompt get <prompt-id>
+opencase prompt submit --matter-id <uuid> "What Brady material exists?"
+```
+
+All prompt endpoints return stub responses. RAG integration
+will be added in Feature 9.
+
 ### Firm
 
 ```bash

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -52,10 +52,44 @@ erDiagram
         timestamptz assigned_at
     }
 
+    documents {
+        uuid id PK
+        uuid firm_id FK
+        uuid matter_id FK
+        string filename
+        string file_hash "SHA-256 hex digest — dedup key"
+        string content_type
+        int size_bytes
+        enum source "government_production | defense | court | work_product"
+        enum classification "brady | giglio | jencks | rule16 | work_product | inculpatory | unclassified"
+        string bates_number "nullable"
+        bool legal_hold
+        uuid uploaded_by FK
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    prompts {
+        uuid id PK
+        uuid firm_id FK
+        uuid matter_id FK
+        text query
+        text response "nullable — stub for now"
+        uuid created_by FK
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
     firms ||--o{ users : "has"
     firms ||--o{ matters : "owns"
+    firms ||--o{ documents : "scoped to"
+    firms ||--o{ prompts : "scoped to"
     users ||--o{ matter_access : "access controlled via"
     matters ||--o{ matter_access : "access controlled via"
+    matters ||--o{ documents : "contains"
+    matters ||--o{ prompts : "queried within"
+    users ||--o{ documents : "uploaded by"
+    users ||--o{ prompts : "created by"
 ```
 
 ## Key Constraints
@@ -68,6 +102,13 @@ erDiagram
 | `matter_access` | Composite PK `(user_id, matter_id)` | One access row per user/matter pair |
 | `matter_access` | `fk_matter_access_user_id_users` | Cascades on user delete |
 | `matter_access` | `fk_matter_access_matter_id_matters` | Cascades on matter delete |
+| `documents` | `uq_documents_matter_id_file_hash` | Same file (by SHA-256) within same matter is rejected |
+| `documents` | `fk_documents_firm_id_firms` | Cascades on firm delete |
+| `documents` | `fk_documents_matter_id_matters` | Cascades on matter delete |
+| `documents` | `fk_documents_uploaded_by_users` | Cascades on user delete |
+| `prompts` | `fk_prompts_firm_id_firms` | Cascades on firm delete |
+| `prompts` | `fk_prompts_matter_id_matters` | Cascades on matter delete |
+| `prompts` | `fk_prompts_created_by_users` | Cascades on user delete |
 
 ## Notes
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -25,7 +25,7 @@
 | 1.5 | RBAC middleware (role enforcement, `build_qdrant_filter()`) | Done | Done | Done |
 | 1.6 | Python REST client SDK + shared models (sdk/, shared/) | Done | Done | Done |
 | 1.7 | CLI (built on SDK) | Done | Done | Done |
-| 1.8 | Core business endpoints (matters, prompt stub, documents stub) | Pending | Pending | Pending |
+| 1.8 | Core business endpoints (matters, prompt stub, documents stub) | Done | Done | Done |
 
 ## Feature 2 — Worker Queue
 

--- a/sdk/opencase/client.py
+++ b/sdk/opencase/client.py
@@ -12,6 +12,10 @@ from shared.models.auth import (
     TokenResponse,
 )
 from shared.models.base import MessageResponse
+from shared.models.document import (
+    DocumentResponse,
+    DocumentSummary,
+)
 from shared.models.firm import FirmResponse
 from shared.models.health import HealthResponse, ReadinessResponse
 from shared.models.matter import (
@@ -20,6 +24,10 @@ from shared.models.matter import (
 )
 from shared.models.matter_access import (
     MatterAccessResponse,
+)
+from shared.models.prompt import (
+    PromptResponse,
+    PromptSummary,
 )
 from shared.models.user import (
     UserResponse,
@@ -243,6 +251,58 @@ class OpenCaseClient:
     def revoke_matter_access(self, matter_id: str, user_id: str) -> MessageResponse:
         resp = self._request("DELETE", f"/matters/{matter_id}/access/{user_id}")
         return MessageResponse.model_validate(resp.json())
+
+    # -- documents -----------------------------------------------------------
+
+    def list_documents(self) -> list[DocumentSummary]:
+        resp = self._request("GET", "/documents/")
+        return [DocumentSummary.model_validate(item) for item in resp.json()]
+
+    def get_document(self, document_id: str) -> DocumentResponse:
+        resp = self._request("GET", f"/documents/{document_id}")
+        return DocumentResponse.model_validate(resp.json())
+
+    def upload_document(
+        self,
+        *,
+        matter_id: str,
+        filename: str,
+        content_type: str,
+        size_bytes: int,
+        file_hash: str,
+        source: str = "defense",
+        classification: str = "unclassified",
+        bates_number: str | None = None,
+    ) -> DocumentResponse:
+        payload: dict[str, Any] = {
+            "matter_id": matter_id,
+            "filename": filename,
+            "content_type": content_type,
+            "size_bytes": size_bytes,
+            "file_hash": file_hash,
+            "source": source,
+            "classification": classification,
+        }
+        if bates_number is not None:
+            payload["bates_number"] = bates_number
+        resp = self._request("POST", "/documents/", json=payload)
+        return DocumentResponse.model_validate(resp.json())
+
+    # -- prompts -------------------------------------------------------------
+
+    def list_prompts(self) -> list[PromptSummary]:
+        resp = self._request("GET", "/prompts/")
+        return [PromptSummary.model_validate(item) for item in resp.json()]
+
+    def get_prompt(self, prompt_id: str) -> PromptResponse:
+        resp = self._request("GET", f"/prompts/{prompt_id}")
+        return PromptResponse.model_validate(resp.json())
+
+    def submit_prompt(self, *, matter_id: str, query: str) -> PromptResponse:
+        resp = self._request(
+            "POST", "/prompts/", json={"matter_id": matter_id, "query": query}
+        )
+        return PromptResponse.model_validate(resp.json())
 
     # -- internal transport --------------------------------------------------
 

--- a/shared/shared/models/__init__.py
+++ b/shared/shared/models/__init__.py
@@ -12,7 +12,12 @@ from shared.models.auth import (
     TokenResponse,
 )
 from shared.models.base import MessageResponse
-from shared.models.enums import MatterStatus, Role
+from shared.models.document import (
+    CreateDocumentRequest,
+    DocumentResponse,
+    DocumentSummary,
+)
+from shared.models.enums import Classification, DocumentSource, MatterStatus, Role
 from shared.models.firm import FirmResponse
 from shared.models.health import HealthResponse, ReadinessResponse, ServiceChecks
 from shared.models.matter import (
@@ -26,6 +31,7 @@ from shared.models.matter_access import (
     MatterAccessResponse,
     RevokeAccessRequest,
 )
+from shared.models.prompt import CreatePromptRequest, PromptResponse, PromptSummary
 from shared.models.user import (
     CreateUserRequest,
     UpdateUserRequest,
@@ -34,8 +40,14 @@ from shared.models.user import (
 )
 
 __all__ = [
+    "Classification",
+    "CreateDocumentRequest",
     "CreateMatterRequest",
+    "CreatePromptRequest",
     "CreateUserRequest",
+    "DocumentResponse",
+    "DocumentSource",
+    "DocumentSummary",
     "FirmResponse",
     "GrantAccessRequest",
     "HealthResponse",
@@ -51,6 +63,8 @@ __all__ = [
     "MfaSetupResponse",
     "MfaStatusResponse",
     "MfaVerifyRequest",
+    "PromptResponse",
+    "PromptSummary",
     "ReadinessResponse",
     "RefreshRequest",
     "RevokeAccessRequest",

--- a/shared/shared/models/document.py
+++ b/shared/shared/models/document.py
@@ -1,0 +1,54 @@
+"""Pydantic request/response models for document endpoints."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from shared.models.enums import Classification, DocumentSource
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class DocumentSummary(BaseModel):
+    """Lightweight document reference (for lists)."""
+
+    id: UUID
+    filename: str
+    content_type: str
+    size_bytes: int
+    source: DocumentSource
+    classification: Classification
+    legal_hold: bool
+    matter_id: UUID
+
+
+class DocumentResponse(DocumentSummary):
+    """Full document detail (single-document endpoint)."""
+
+    firm_id: UUID
+    file_hash: str
+    bates_number: str | None
+    uploaded_by: UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class CreateDocumentRequest(BaseModel):
+    matter_id: UUID
+    filename: str = Field(min_length=1, max_length=512)
+    content_type: str = Field(min_length=1, max_length=255)
+    size_bytes: int = Field(ge=0)
+    file_hash: str = Field(
+        min_length=64, max_length=64, description="SHA-256 hex digest"
+    )
+    source: DocumentSource = DocumentSource.defense
+    classification: Classification = Classification.unclassified
+    bates_number: str | None = Field(default=None, max_length=100)

--- a/shared/shared/models/enums.py
+++ b/shared/shared/models/enums.py
@@ -14,3 +14,20 @@ class MatterStatus(enum.StrEnum):
     open = "open"
     closed = "closed"
     archived = "archived"
+
+
+class DocumentSource(enum.StrEnum):
+    government_production = "government_production"
+    defense = "defense"
+    court = "court"
+    work_product = "work_product"
+
+
+class Classification(enum.StrEnum):
+    brady = "brady"
+    giglio = "giglio"
+    jencks = "jencks"
+    rule16 = "rule16"
+    work_product = "work_product"
+    inculpatory = "inculpatory"
+    unclassified = "unclassified"

--- a/shared/shared/models/prompt.py
+++ b/shared/shared/models/prompt.py
@@ -1,0 +1,38 @@
+"""Pydantic request/response models for prompt endpoints."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class PromptSummary(BaseModel):
+    """Lightweight prompt reference (for lists)."""
+
+    id: UUID
+    matter_id: UUID
+    query: str
+    created_at: datetime
+
+
+class PromptResponse(PromptSummary):
+    """Full prompt detail (single-prompt endpoint)."""
+
+    firm_id: UUID
+    response: str | None
+    created_by: UUID
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class CreatePromptRequest(BaseModel):
+    matter_id: UUID
+    query: str = Field(min_length=1, max_length=10000)


### PR DESCRIPTION
## Summary

- Add stub API endpoints for documents (`POST`, `GET /`, `GET /{id}`) and prompts (`POST`, `GET /`, `GET /{id}`)
- Add `Document` and `Prompt` SQLAlchemy models with Alembic migration (`0003`)
- Add `DocumentSource` and `Classification` enums to shared models
- Add shared Pydantic request/response models for both resources
- Add 6 SDK methods (`upload_document`, `list_documents`, `get_document`, `submit_prompt`, `list_prompts`, `get_prompt`)
- Add CLI commands (`opencase document list/get/upload`, `opencase prompt list/get/submit`)
- Add OTel metrics (`documents_created`, `prompts_created`)
- Extract shared `FakeSession` test helper to `conftest.py` (DRY)
- Update FEATURES.md (1.8 → Done), CLI.md, and ERD.md

## Test plan

- [x] 11 new endpoint tests (stub responses, validation, 404s) — all pass
- [x] 22 existing entity endpoint tests — all still pass
- [x] All pre-commit hooks pass (ruff, mypy, pytest across all packages)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)