### PR TITLE
feat: add CelerySettings, RedisSettings, FlowerSettings config (Feature 2.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,7 +146,8 @@ OPENCASE_REDIS_POOL_SIZE="10"
 # =============================================================================
 # Celery (OPENCASE_CELERY_ prefix — read by pydantic-settings)
 # =============================================================================
-# Broker URL — must match Redis settings above
+# Broker URL — must match Redis settings above (host, port, db, password)
+# Update this if you override OPENCASE_REDIS_HOST, PORT, DB, or PASSWORD.
 OPENCASE_CELERY_BROKER_URL="redis://redis:6379/0"
 # Result backend — tasks PostgreSQL DSN (set when tasks DB is provisioned)
 # OPENCASE_CELERY_RESULT_BACKEND=""

--- a/.env.example
+++ b/.env.example
@@ -128,6 +128,56 @@ OPENCASE_OTEL_SERVICE_NAME="opencase-api"
 OPENCASE_OTEL_SAMPLE_RATE="1.0"
 
 # =============================================================================
+# Redis (OPENCASE_REDIS_ prefix — read by pydantic-settings)
+# =============================================================================
+# Redis host (Docker service name inside compose network)
+OPENCASE_REDIS_HOST="redis"
+# Redis port
+OPENCASE_REDIS_PORT="6379"
+# Redis database number (0–15)
+OPENCASE_REDIS_DB="0"
+# Redis password (optional — leave blank for no authentication)
+# OPENCASE_REDIS_PASSWORD=""
+# Enable TLS/SSL for Redis connections
+OPENCASE_REDIS_SSL="false"
+# Connection pool size
+OPENCASE_REDIS_POOL_SIZE="10"
+
+# =============================================================================
+# Celery (OPENCASE_CELERY_ prefix — read by pydantic-settings)
+# =============================================================================
+# Broker URL — must match Redis settings above
+OPENCASE_CELERY_BROKER_URL="redis://redis:6379/0"
+# Result backend — tasks PostgreSQL DSN (set when tasks DB is provisioned)
+# OPENCASE_CELERY_RESULT_BACKEND=""
+# Task serialization format
+OPENCASE_CELERY_TASK_SERIALIZER="json"
+# Accepted content types (JSON array)
+OPENCASE_CELERY_ACCEPT_CONTENT='["json"]'
+# Timezone for scheduled tasks
+OPENCASE_CELERY_TIMEZONE="UTC"
+# Number of concurrent worker processes
+OPENCASE_CELERY_WORKER_CONCURRENCY="2"
+# Soft time limit per task in seconds (5 min)
+OPENCASE_CELERY_TASK_SOFT_TIME_LIMIT="300"
+# Hard time limit per task in seconds (10 min)
+OPENCASE_CELERY_TASK_HARD_TIME_LIMIT="600"
+# Acknowledge tasks after completion (safer for crash recovery)
+OPENCASE_CELERY_TASK_ACKS_LATE="true"
+# Tasks prefetched per worker (1 = fair scheduling)
+OPENCASE_CELERY_WORKER_PREFETCH_MULTIPLIER="1"
+
+# =============================================================================
+# Flower (OPENCASE_FLOWER_ prefix — read by pydantic-settings)
+# =============================================================================
+# Flower web UI port
+OPENCASE_FLOWER_PORT="5555"
+# Basic auth credentials (format: user:password, optional)
+# OPENCASE_FLOWER_BASIC_AUTH=""
+# URL prefix for reverse proxy
+OPENCASE_FLOWER_URL_PREFIX="/flower"
+
+# =============================================================================
 # Cloud Ingestion — Azure (internet mode only)
 # =============================================================================
 # Required only when DEPLOYMENT_MODE="internet"

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -89,3 +89,31 @@ OPENCASE_ADMIN_PASSWORD="Hq105loxzTCYcMp2AyUGF+Ldxyg3zz8Q"
 OPENCASE_ADMIN_FIRST_NAME="Test"
 OPENCASE_ADMIN_LAST_NAME="Admin"
 OPENCASE_ADMIN_FIRM_NAME="Test Firm"
+
+# =============================================================================
+# Redis
+# =============================================================================
+OPENCASE_REDIS_HOST="localhost"
+OPENCASE_REDIS_PORT="6379"
+OPENCASE_REDIS_DB="0"
+OPENCASE_REDIS_SSL="false"
+OPENCASE_REDIS_POOL_SIZE="10"
+
+# =============================================================================
+# Celery
+# =============================================================================
+OPENCASE_CELERY_BROKER_URL="redis://localhost:6379/0"
+OPENCASE_CELERY_TASK_SERIALIZER="json"
+OPENCASE_CELERY_ACCEPT_CONTENT='["json"]'
+OPENCASE_CELERY_TIMEZONE="UTC"
+OPENCASE_CELERY_WORKER_CONCURRENCY="2"
+OPENCASE_CELERY_TASK_SOFT_TIME_LIMIT="300"
+OPENCASE_CELERY_TASK_HARD_TIME_LIMIT="600"
+OPENCASE_CELERY_TASK_ACKS_LATE="true"
+OPENCASE_CELERY_WORKER_PREFETCH_MULTIPLIER="1"
+
+# =============================================================================
+# Flower
+# =============================================================================
+OPENCASE_FLOWER_PORT="5555"
+OPENCASE_FLOWER_URL_PREFIX="/flower"

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -102,6 +102,7 @@ OPENCASE_REDIS_POOL_SIZE="10"
 # =============================================================================
 # Celery
 # =============================================================================
+# Must match OPENCASE_REDIS_HOST above (localhost for host-side tests)
 OPENCASE_CELERY_BROKER_URL="redis://localhost:6379/0"
 OPENCASE_CELERY_TASK_SERIALIZER="json"
 OPENCASE_CELERY_ACCEPT_CONTENT='["json"]'

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,7 @@
 from importlib.metadata import version
 from typing import Any, Literal
 
-from pydantic import Field
+from pydantic import Field, computed_field
 from pydantic_settings import (
     BaseSettings,
     JsonConfigSettingsSource,
@@ -88,6 +88,92 @@ class AdminSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="OPENCASE_ADMIN_")
 
 
+class RedisSettings(BaseSettings):
+    """Redis sub-config (OPENCASE_REDIS_ prefix).
+
+    Individual fields are preferred over a monolithic URL so that each
+    component is independently overridable and visible in documentation.
+    The computed ``url`` property assembles them into a connection string.
+    """
+
+    host: str = "redis"
+    port: int = 6379
+    db: int = 0
+    password: str | None = None
+    ssl: bool = False
+    pool_size: int = 10
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def url(self) -> str:
+        scheme = "rediss" if self.ssl else "redis"
+        auth = f":{self.password}@" if self.password else ""
+        return f"{scheme}://{auth}{self.host}:{self.port}/{self.db}"
+
+    model_config = SettingsConfigDict(env_prefix="OPENCASE_REDIS_")
+
+
+class CelerySettings(BaseSettings):
+    """Celery sub-config (OPENCASE_CELERY_ prefix).
+
+    broker_url defaults to the Docker-internal Redis address.
+    result_backend is None until the tasks database is provisioned
+    (Feature 2.4).
+    """
+
+    broker_url: str = "redis://redis:6379/0"
+    result_backend: str | None = None
+    task_serializer: str = "json"
+    accept_content: list[str] = Field(default=["json"])
+    timezone: str = "UTC"
+    worker_concurrency: int = 2
+    task_soft_time_limit: int = 300
+    task_hard_time_limit: int = 600
+    task_acks_late: bool = True
+    worker_prefetch_multiplier: int = 1
+
+    model_config = SettingsConfigDict(env_prefix="OPENCASE_CELERY_")
+
+
+class FlowerSettings(BaseSettings):
+    """Flower monitoring UI sub-config (OPENCASE_FLOWER_ prefix)."""
+
+    port: int = 5555
+    basic_auth: str | None = None
+    url_prefix: str = "/flower"
+
+    model_config = SettingsConfigDict(env_prefix="OPENCASE_FLOWER_")
+
+
+# ---------------------------------------------------------------------------
+# Secret redaction
+# ---------------------------------------------------------------------------
+
+_SECRET_SUBSTRINGS = ("password", "secret")
+_SECRET_EXACT = frozenset({"basic_auth", "broker_url", "result_backend"})
+
+
+def redact_settings(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a nested settings dict with sensitive values masked."""
+    out: dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, dict):
+            out[key] = redact_settings(value)
+        elif isinstance(value, list):
+            out[key] = [
+                redact_settings(item) if isinstance(item, dict) else item
+                for item in value
+            ]
+        elif value is not None and (
+            any(s in key.lower() for s in _SECRET_SUBSTRINGS)
+            or key.lower() in _SECRET_EXACT
+        ):
+            out[key] = "***REDACTED***"
+        else:
+            out[key] = value
+    return out
+
+
 class Settings(BaseSettings):
     """Application settings with layered loading.
 
@@ -109,6 +195,9 @@ class Settings(BaseSettings):
     auth: AuthSettings = AuthSettings()  # type: ignore[call-arg]
     db: DbSettings = DbSettings()  # type: ignore[call-arg]
     admin: AdminSettings = AdminSettings()
+    redis: RedisSettings = RedisSettings()
+    celery: CelerySettings = CelerySettings()
+    flower: FlowerSettings = FlowerSettings()
 
     model_config = SettingsConfigDict(
         env_prefix="OPENCASE_",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,6 @@
 from importlib.metadata import version
 from typing import Any, Literal
+from urllib.parse import quote, urlparse
 
 from pydantic import Field, computed_field
 from pydantic_settings import (
@@ -107,7 +108,7 @@ class RedisSettings(BaseSettings):
     @property
     def url(self) -> str:
         scheme = "rediss" if self.ssl else "redis"
-        auth = f":{self.password}@" if self.password else ""
+        auth = f":{quote(self.password, safe='')}@" if self.password else ""
         return f"{scheme}://{auth}{self.host}:{self.port}/{self.db}"
 
     model_config = SettingsConfigDict(env_prefix="OPENCASE_REDIS_")
@@ -116,7 +117,11 @@ class RedisSettings(BaseSettings):
 class CelerySettings(BaseSettings):
     """Celery sub-config (OPENCASE_CELERY_ prefix).
 
-    broker_url defaults to the Docker-internal Redis address.
+    broker_url defaults to the Docker-internal Redis address and must be
+    kept in sync with RedisSettings (host, port, db, password, ssl).
+    When overriding RedisSettings fields, update broker_url to match or
+    set OPENCASE_CELERY_BROKER_URL explicitly.
+
     result_backend is None until the tasks database is provisioned
     (Feature 2.4).
     """
@@ -124,7 +129,7 @@ class CelerySettings(BaseSettings):
     broker_url: str = "redis://redis:6379/0"
     result_backend: str | None = None
     task_serializer: str = "json"
-    accept_content: list[str] = Field(default=["json"])
+    accept_content: list[str] = Field(default_factory=lambda: ["json"])
     timezone: str = "UTC"
     worker_concurrency: int = 2
     task_soft_time_limit: int = 300
@@ -150,7 +155,20 @@ class FlowerSettings(BaseSettings):
 # ---------------------------------------------------------------------------
 
 _SECRET_SUBSTRINGS = ("password", "secret")
-_SECRET_EXACT = frozenset({"basic_auth", "broker_url", "result_backend"})
+_SECRET_EXACT = frozenset({"basic_auth"})
+_URL_FIELDS = frozenset({"broker_url", "result_backend", "url"})
+
+
+def _redact_url(value: str) -> str:
+    """Redact only the password component of a URL, preserving host/port/path."""
+    try:
+        parsed = urlparse(value)
+    except Exception:
+        return "***REDACTED***"
+    if parsed.password:
+        replaced = parsed.netloc.replace(f":{parsed.password}@", ":***@")
+        return parsed._replace(netloc=replaced).geturl()
+    return value
 
 
 def redact_settings(data: dict[str, Any]) -> dict[str, Any]:
@@ -169,6 +187,8 @@ def redact_settings(data: dict[str, Any]) -> dict[str, Any]:
             or key.lower() in _SECRET_EXACT
         ):
             out[key] = "***REDACTED***"
+        elif isinstance(value, str) and key.lower() in _URL_FIELDS:
+            out[key] = _redact_url(value)
         else:
             out[key] = value
     return out

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ from app.core.telemetry import configure_instrumentation, setup_telemetry  # noq
 logger = logging.getLogger(__name__)
 
 setup_telemetry(settings)
-logger.info("Settings loaded: %s", redact_settings(settings.model_dump()))
+logger.debug("Settings loaded: %s", redact_settings(settings.model_dump()))
 
 
 @asynccontextmanager

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 # Configure logging before any other app imports.
 # session.py and other modules emit logger.debug() at import time;
 # setup_logging() must run first so those messages respect OPENCASE_LOG_LEVEL.
-from app.core.config import settings
+from app.core.config import redact_settings, settings
 from app.core.logging import setup_logging
 
 setup_logging(settings.log_level, settings.log_output)
@@ -25,6 +25,7 @@ from app.core.telemetry import configure_instrumentation, setup_telemetry  # noq
 logger = logging.getLogger(__name__)
 
 setup_telemetry(settings)
+logger.info("Settings loaded: %s", redact_settings(settings.model_dump()))
 
 
 @asynccontextmanager

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -285,6 +285,12 @@ def test_redis_url_with_password(monkeypatch):
     assert cfg.url == "redis://:s3cret@localhost:6379/0"
 
 
+def test_redis_url_encodes_special_chars(monkeypatch):
+    monkeypatch.setenv("OPENCASE_REDIS_PASSWORD", "p@ss/word")
+    cfg = RedisSettings()
+    assert cfg.url == "redis://:p%40ss%2Fword@localhost:6379/0"
+
+
 def test_redis_url_ssl(monkeypatch):
     monkeypatch.setenv("OPENCASE_REDIS_SSL", "true")
     cfg = RedisSettings()
@@ -403,9 +409,19 @@ def test_redact_settings_masks_secrets():
     assert redacted["flower"]["port"] == 5555
     assert redacted["redis"]["password"] == _REDACTED
     assert redacted["redis"]["host"] == "redis"
-    assert redacted["celery"]["broker_url"] == _REDACTED
-    assert redacted["celery"]["result_backend"] == _REDACTED
+    # URL fields redact only the password component, not the whole URL
+    assert redacted["celery"]["broker_url"] == "redis://:***@redis:6379/0"
+    assert (
+        redacted["celery"]["result_backend"] == "db+postgresql+psycopg2://u:***@host/db"
+    )
     assert redacted["celery"]["timezone"] == "UTC"
+
+
+def test_redact_settings_url_without_password():
+    data = {"celery": {"broker_url": "redis://redis:6379/0"}}
+    redacted = redact_settings(data)
+    # No password in URL — passed through unchanged
+    assert redacted["celery"]["broker_url"] == "redis://redis:6379/0"
 
 
 def test_redact_settings_skips_none():

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -13,7 +13,16 @@ import pytest
 from dotenv import dotenv_values
 from pydantic import ValidationError
 
-from app.core.config import ApiSettings, AuthSettings, DbSettings, Settings
+from app.core.config import (
+    ApiSettings,
+    AuthSettings,
+    CelerySettings,
+    DbSettings,
+    FlowerSettings,
+    RedisSettings,
+    Settings,
+    redact_settings,
+)
 
 # Read required test values from .env.test — single source of truth.
 _ENV_TEST = dotenv_values(Path(__file__).parent.parent / ".env.test")
@@ -61,6 +70,34 @@ DEFAULTS = {
         "first_name": _ENV_TEST.get("OPENCASE_ADMIN_FIRST_NAME", "Admin"),
         "last_name": _ENV_TEST.get("OPENCASE_ADMIN_LAST_NAME", "User"),
         "firm_name": _ENV_TEST.get("OPENCASE_ADMIN_FIRM_NAME", "Default Firm"),
+    },
+    "redis": {
+        "host": _ENV_TEST.get("OPENCASE_REDIS_HOST", "redis"),
+        "port": int(_ENV_TEST.get("OPENCASE_REDIS_PORT", "6379")),
+        "db": int(_ENV_TEST.get("OPENCASE_REDIS_DB", "0")),
+        "password": None,
+        "ssl": False,
+        "pool_size": int(_ENV_TEST.get("OPENCASE_REDIS_POOL_SIZE", "10")),
+        "url": f"redis://{_ENV_TEST.get('OPENCASE_REDIS_HOST', 'redis')}:6379/0",
+    },
+    "celery": {
+        "broker_url": _ENV_TEST.get(
+            "OPENCASE_CELERY_BROKER_URL", "redis://redis:6379/0"
+        ),
+        "result_backend": None,
+        "task_serializer": "json",
+        "accept_content": ["json"],
+        "timezone": "UTC",
+        "worker_concurrency": 2,
+        "task_soft_time_limit": 300,
+        "task_hard_time_limit": 600,
+        "task_acks_late": True,
+        "worker_prefetch_multiplier": 1,
+    },
+    "flower": {
+        "port": 5555,
+        "basic_auth": None,
+        "url_prefix": "/flower",
     },
 }
 
@@ -220,3 +257,166 @@ def test_db_prefix_isolation(monkeypatch):
     monkeypatch.delenv("OPENCASE_DB_URL", raising=False)
     with pytest.raises(ValidationError):
         DbSettings()
+
+
+# ---------------------------------------------------------------------------
+# RedisSettings — tested directly
+# ---------------------------------------------------------------------------
+
+
+def test_redis_defaults():
+    cfg = RedisSettings()
+    assert cfg.host == "localhost"  # from .env.test
+    assert cfg.port == 6379
+    assert cfg.db == 0
+    assert cfg.password is None
+    assert cfg.ssl is False
+    assert cfg.pool_size == 10
+
+
+def test_redis_url_no_password():
+    cfg = RedisSettings()
+    assert cfg.url == "redis://localhost:6379/0"
+
+
+def test_redis_url_with_password(monkeypatch):
+    monkeypatch.setenv("OPENCASE_REDIS_PASSWORD", "s3cret")
+    cfg = RedisSettings()
+    assert cfg.url == "redis://:s3cret@localhost:6379/0"
+
+
+def test_redis_url_ssl(monkeypatch):
+    monkeypatch.setenv("OPENCASE_REDIS_SSL", "true")
+    cfg = RedisSettings()
+    assert cfg.url.startswith("rediss://")
+
+
+def test_redis_env_override(monkeypatch):
+    monkeypatch.setenv("OPENCASE_REDIS_PORT", "6380")
+    cfg = RedisSettings()
+    assert cfg.port == 6380
+
+
+def test_redis_prefix_isolation(monkeypatch):
+    # OPENCASE_HOST (wrong prefix) must not override OPENCASE_REDIS_HOST
+    monkeypatch.setenv("OPENCASE_HOST", "wrong")
+    cfg = RedisSettings()
+    assert cfg.host != "wrong"
+
+
+# ---------------------------------------------------------------------------
+# CelerySettings — tested directly
+# ---------------------------------------------------------------------------
+
+
+def test_celery_defaults():
+    cfg = CelerySettings()
+    assert cfg.broker_url == "redis://localhost:6379/0"  # from .env.test
+    assert cfg.result_backend is None
+    assert cfg.task_serializer == "json"
+    assert cfg.accept_content == ["json"]
+    assert cfg.timezone == "UTC"
+    assert cfg.worker_concurrency == 2
+    assert cfg.task_soft_time_limit == 300
+    assert cfg.task_hard_time_limit == 600
+    assert cfg.task_acks_late is True
+    assert cfg.worker_prefetch_multiplier == 1
+
+
+def test_celery_env_override(monkeypatch):
+    monkeypatch.setenv("OPENCASE_CELERY_WORKER_CONCURRENCY", "4")
+    cfg = CelerySettings()
+    assert cfg.worker_concurrency == 4
+
+
+def test_celery_result_backend_override(monkeypatch):
+    dsn = "db+postgresql+psycopg2://user:pass@tasks-db:5432/celery"
+    monkeypatch.setenv("OPENCASE_CELERY_RESULT_BACKEND", dsn)
+    cfg = CelerySettings()
+    assert cfg.result_backend == dsn
+
+
+def test_celery_prefix_isolation(monkeypatch):
+    # OPENCASE_BROKER_URL (wrong prefix) must not override OPENCASE_CELERY_BROKER_URL
+    monkeypatch.setenv("OPENCASE_BROKER_URL", "wrong")
+    cfg = CelerySettings()
+    assert cfg.broker_url != "wrong"
+
+
+# ---------------------------------------------------------------------------
+# FlowerSettings — tested directly
+# ---------------------------------------------------------------------------
+
+
+def test_flower_defaults():
+    cfg = FlowerSettings()
+    assert cfg.port == 5555
+    assert cfg.basic_auth is None
+    assert cfg.url_prefix == "/flower"
+
+
+def test_flower_env_override(monkeypatch):
+    monkeypatch.setenv("OPENCASE_FLOWER_PORT", "5556")
+    cfg = FlowerSettings()
+    assert cfg.port == 5556
+
+
+def test_flower_basic_auth(monkeypatch):
+    monkeypatch.setenv("OPENCASE_FLOWER_BASIC_AUTH", "admin:secret")
+    cfg = FlowerSettings()
+    assert cfg.basic_auth == "admin:secret"
+
+
+def test_flower_prefix_isolation(monkeypatch):
+    # OPENCASE_PORT (wrong prefix) must not override OPENCASE_FLOWER_PORT
+    monkeypatch.setenv("OPENCASE_PORT", "9999")
+    cfg = FlowerSettings()
+    assert cfg.port == 5555
+
+
+# ---------------------------------------------------------------------------
+# redact_settings
+# ---------------------------------------------------------------------------
+
+
+_REDACTED = "***REDACTED***"
+
+
+def test_redact_settings_masks_secrets():
+    data = {
+        "auth": {"secret_key": "real-secret", "algorithm": "HS256"},
+        "admin": {"password": "real-pw", "email": "a@b.com"},
+        "flower": {"basic_auth": "user:pass", "port": 5555},
+        "redis": {"password": "redis-pw", "host": "redis"},
+        "celery": {
+            "broker_url": "redis://:s3cret@redis:6379/0",
+            "result_backend": "db+postgresql+psycopg2://u:p@host/db",
+            "timezone": "UTC",
+        },
+    }
+    redacted = redact_settings(data)
+    assert redacted["auth"]["secret_key"] == _REDACTED
+    assert redacted["auth"]["algorithm"] == "HS256"
+    assert redacted["admin"]["password"] == _REDACTED
+    assert redacted["admin"]["email"] == "a@b.com"
+    assert redacted["flower"]["basic_auth"] == _REDACTED
+    assert redacted["flower"]["port"] == 5555
+    assert redacted["redis"]["password"] == _REDACTED
+    assert redacted["redis"]["host"] == "redis"
+    assert redacted["celery"]["broker_url"] == _REDACTED
+    assert redacted["celery"]["result_backend"] == _REDACTED
+    assert redacted["celery"]["timezone"] == "UTC"
+
+
+def test_redact_settings_skips_none():
+    data = {"redis": {"password": None, "host": "redis"}}
+    redacted = redact_settings(data)
+    assert redacted["redis"]["password"] is None
+
+
+def test_redact_settings_recurses_into_lists():
+    data = {"items": [{"password": "pw", "name": "a"}, {"host": "b"}]}
+    redacted = redact_settings(data)
+    assert redacted["items"][0]["password"] == _REDACTED
+    assert redacted["items"][0]["name"] == "a"
+    assert redacted["items"][1]["host"] == "b"

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -31,7 +31,7 @@
 
 | ID | Feature | Specs | Code | Docs |
 | --- | --- | --- | --- | --- |
-| 2.1 | Configuration + env vars (CelerySettings, RedisSettings, FlowerSettings) | Pending | Pending | Pending |
+| 2.1 | Configuration + env vars (CelerySettings, RedisSettings, FlowerSettings) | Pending | Done | Done |
 | 2.2 | Redis broker container | Pending | Pending | Pending |
 | 2.3 | Celery app + task definitions (app/workers/) | Pending | Pending | Pending |
 | 2.4 | Task result persistence (separate Postgres instance, task lifecycle table for audit) | Pending | Pending | Pending |

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -97,3 +97,58 @@ on-premise.
 When `EXPORTER=otlp`, the Grafana UI is available at `http://localhost:3001`
 with pre-configured datasources for Tempo (traces), Prometheus (metrics), and
 Loki (logs).
+
+---
+
+## RedisSettings (`OPENCASE_REDIS_` prefix)
+
+Redis connection settings. Individual fields are preferred over a monolithic URL
+so each component is independently overridable. A computed `url` property
+assembles them into a connection string at runtime.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENCASE_REDIS_HOST` | `redis` | Redis host (Docker service name) |
+| `OPENCASE_REDIS_PORT` | `6379` | Redis port |
+| `OPENCASE_REDIS_DB` | `0` | Redis database number (0–15) |
+| `OPENCASE_REDIS_PASSWORD` | *none* | Redis password (optional) |
+| `OPENCASE_REDIS_SSL` | `false` | Enable TLS/SSL (`rediss://` scheme) |
+| `OPENCASE_REDIS_POOL_SIZE` | `10` | Connection pool max connections |
+
+The computed `url` property (e.g. `redis://redis:6379/0`) is available in
+Python as `settings.redis.url` but is not set via an environment variable.
+
+---
+
+## CelerySettings (`OPENCASE_CELERY_` prefix)
+
+Celery task queue configuration.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENCASE_CELERY_BROKER_URL` | `redis://redis:6379/0` | Message broker URL |
+| `OPENCASE_CELERY_RESULT_BACKEND` | *none* | Task result backend DSN (set when tasks DB is provisioned) |
+| `OPENCASE_CELERY_TASK_SERIALIZER` | `json` | Task serialization format |
+| `OPENCASE_CELERY_ACCEPT_CONTENT` | `["json"]` | Accepted content types (JSON array) |
+| `OPENCASE_CELERY_TIMEZONE` | `UTC` | Timezone for scheduled tasks |
+| `OPENCASE_CELERY_WORKER_CONCURRENCY` | `2` | Concurrent worker processes |
+| `OPENCASE_CELERY_TASK_SOFT_TIME_LIMIT` | `300` | Soft time limit per task (seconds) |
+| `OPENCASE_CELERY_TASK_HARD_TIME_LIMIT` | `600` | Hard time limit per task (seconds) |
+| `OPENCASE_CELERY_TASK_ACKS_LATE` | `true` | Acknowledge after completion (crash-safe) |
+| `OPENCASE_CELERY_WORKER_PREFETCH_MULTIPLIER` | `1` | Tasks prefetched per worker (1 = fair) |
+
+`OPENCASE_CELERY_RESULT_BACKEND` is optional until the tasks database is
+provisioned (Feature 2.4). When set, use a synchronous psycopg2 DSN:
+`db+postgresql+psycopg2://user:pass@tasks-db:5432/celery`.
+
+---
+
+## FlowerSettings (`OPENCASE_FLOWER_` prefix)
+
+Flower monitoring UI for Celery.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENCASE_FLOWER_PORT` | `5555` | Flower web UI port |
+| `OPENCASE_FLOWER_BASIC_AUTH` | *none* | Basic auth credentials (`user:password`, optional) |
+| `OPENCASE_FLOWER_URL_PREFIX` | `/flower` | URL prefix for reverse proxy |


### PR DESCRIPTION
## Summary

- Add `RedisSettings`, `CelerySettings`, `FlowerSettings` pydantic-settings classes to `backend/app/core/config.py` following established pattern
- Add `redact_settings()` helper that masks passwords, secrets, broker URLs, and basic auth in startup logs
- Add Redis computed `url` property from individual host/port/db/password/ssl components
- Add startup config log line with secret redaction in `main.py`
- Update `.env.example`, `.env.test`, `SETTINGS.md`, and `FEATURES.md`
- 34 unit tests passing (18 new)

## Test plan

- [x] `pytest tests/test_config.py` — 34/34 passing
- [x] `pre-commit run --all-files` — ruff-format, ruff, mypy, pytest all pass
- [x] RedisSettings URL construction tested with/without password and SSL
- [x] Secret redaction covers password, secret_key, basic_auth, broker_url, result_backend
- [x] Prefix isolation verified for all three new settings classes

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)