### PR TITLE
feat: add task CRUD API endpoints, SDK, and CLI (Features 2.5–2.6)

### DIFF
--- a/backend/alembic/versions/0004_task_submissions.py
+++ b/backend/alembic/versions/0004_task_submissions.py
@@ -1,0 +1,54 @@
+"""Add task_submissions table.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-03-24 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0004"
+down_revision: str | None = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NOW = sa.text("now()")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "task_submissions",
+        sa.Column("id", sa.String(255), primary_key=True),
+        sa.Column(
+            "firm_id",
+            sa.Uuid(),
+            sa.ForeignKey("firms.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("task_name", sa.String(100), nullable=False, index=True),
+        sa.Column("args_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("kwargs_json", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("status", sa.String(20), nullable=False, server_default="PENDING"),
+        sa.Column(
+            "submitted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=_NOW,
+        ),
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -1,0 +1,276 @@
+"""Task router — submit, list, read, update, and cancel background tasks."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from opentelemetry import trace
+from shared.models.base import MessageResponse
+from shared.models.enums import Role, TaskState
+from shared.models.task import (
+    SubmitTaskRequest,
+    TaskResponse,
+    TaskSubmitResponse,
+    TaskSummary,
+    UpdateTaskRequest,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user
+from app.core.metrics import tasks_cancelled, tasks_submitted
+from app.core.permissions import require_role
+from app.db import get_db
+from app.db.models.task_submission import TaskSubmission
+from app.db.models.user import User
+from app.workers.broker import TaskBroker, get_task_broker
+from app.workers.registry import TASK_REGISTRY
+
+tracer = trace.get_tracer(__name__)
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _submission_to_summary(sub: TaskSubmission) -> TaskSummary:
+    return TaskSummary(
+        id=sub.id,
+        task_name=sub.task_name,
+        status=TaskState(sub.status),
+        submitted_at=sub.submitted_at,
+        submitted_by=sub.user_id,
+    )
+
+
+def _submission_to_response(
+    sub: TaskSubmission,
+    *,
+    status: str | None = None,
+    result: Any = None,
+    date_done: datetime | None = None,
+    traceback: str | None = None,
+) -> TaskResponse:
+    return TaskResponse(
+        id=sub.id,
+        task_name=sub.task_name,
+        status=TaskState(status or sub.status),
+        submitted_at=sub.submitted_at,
+        submitted_by=sub.user_id,
+        firm_id=sub.firm_id,
+        args=json.loads(sub.args_json),
+        kwargs=json.loads(sub.kwargs_json),
+        result=result,
+        date_done=date_done,
+        traceback=traceback,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /tasks/
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/",
+    response_model=TaskSubmitResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={400: {}},
+)
+async def submit_task(
+    body: SubmitTaskRequest,
+    user: User = Depends(require_role(Role.admin, Role.attorney)),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+    broker: TaskBroker = Depends(get_task_broker),  # noqa: B008
+) -> TaskSubmitResponse:
+    with tracer.start_as_current_span(
+        "tasks.submit",
+        attributes={"user.id": str(user.id), "task.name": body.task_name},
+    ):
+        celery_name = TASK_REGISTRY.get(body.task_name)
+        if celery_name is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown task: {body.task_name}",
+            )
+
+        task_id = await asyncio.to_thread(
+            broker.submit, celery_name, body.args, body.kwargs
+        )
+
+        now = datetime.now(UTC)
+        sub = TaskSubmission(
+            id=task_id,
+            firm_id=user.firm_id,
+            user_id=user.id,
+            task_name=body.task_name,
+            args_json=json.dumps(body.args),
+            kwargs_json=json.dumps(body.kwargs),
+            status=TaskState.pending,
+            submitted_at=now,
+        )
+        db.add(sub)
+        try:
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            await asyncio.to_thread(broker.revoke, task_id, terminate=True)
+            raise
+        tasks_submitted.add(1)
+        return TaskSubmitResponse(task_id=task_id)
+
+
+# ---------------------------------------------------------------------------
+# GET /tasks/
+# ---------------------------------------------------------------------------
+
+
+@router.get("/", response_model=list[TaskSummary])
+async def list_tasks(
+    task_status: TaskState | None = Query(None, alias="status"),  # noqa: B008
+    task_name: str | None = Query(None),
+    submitted_after: datetime | None = Query(None),  # noqa: B008
+    submitted_before: datetime | None = Query(None),  # noqa: B008
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> list[TaskSummary]:
+    with tracer.start_as_current_span(
+        "tasks.list",
+        attributes={"user.id": str(user.id)},
+    ):
+        stmt = select(TaskSubmission).where(TaskSubmission.firm_id == user.firm_id)
+
+        if task_status is not None:
+            stmt = stmt.where(TaskSubmission.status == task_status)
+        if task_name is not None:
+            stmt = stmt.where(TaskSubmission.task_name == task_name)
+        if submitted_after is not None:
+            stmt = stmt.where(TaskSubmission.submitted_at >= submitted_after)
+        if submitted_before is not None:
+            stmt = stmt.where(TaskSubmission.submitted_at <= submitted_before)
+
+        stmt = stmt.order_by(TaskSubmission.submitted_at.desc())
+
+        result = await db.execute(stmt)
+        return [_submission_to_summary(s) for s in result.scalars().all()]
+
+
+# ---------------------------------------------------------------------------
+# GET /tasks/{task_id}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{task_id}", response_model=TaskResponse, responses={404: {}})
+async def get_task(
+    task_id: str,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+    broker: TaskBroker = Depends(get_task_broker),  # noqa: B008
+) -> TaskResponse:
+    with tracer.start_as_current_span(
+        "tasks.get",
+        attributes={"user.id": str(user.id), "task.id": task_id},
+    ):
+        stmt = select(TaskSubmission).where(
+            TaskSubmission.id == task_id,
+            TaskSubmission.firm_id == user.firm_id,
+        )
+        result = await db.execute(stmt)
+        sub = result.scalar_one_or_none()
+
+        if sub is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+        # Enrich with live Celery status
+        live = await asyncio.to_thread(broker.get_status, task_id)
+
+        # Update denormalized status if changed
+        if live.state != sub.status:
+            sub.status = live.state
+            await db.commit()
+
+        return _submission_to_response(
+            sub,
+            status=live.state,
+            result=live.result,
+            date_done=live.date_done,
+            traceback=live.traceback,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PUT /tasks/{task_id}  (scaffold)
+# ---------------------------------------------------------------------------
+
+
+@router.put("/{task_id}", response_model=TaskResponse, responses={404: {}})
+async def update_task(
+    task_id: str,
+    body: UpdateTaskRequest,  # noqa: ARG001
+    user: User = Depends(require_role(Role.admin)),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+    broker: TaskBroker = Depends(get_task_broker),  # noqa: B008
+) -> TaskResponse:
+    with tracer.start_as_current_span(
+        "tasks.update",
+        attributes={"user.id": str(user.id), "task.id": task_id},
+    ):
+        stmt = select(TaskSubmission).where(
+            TaskSubmission.id == task_id,
+            TaskSubmission.firm_id == user.firm_id,
+        )
+        result = await db.execute(stmt)
+        sub = result.scalar_one_or_none()
+
+        if sub is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+        live = await asyncio.to_thread(broker.get_status, task_id)
+        return _submission_to_response(
+            sub,
+            status=live.state,
+            result=live.result,
+            date_done=live.date_done,
+            traceback=live.traceback,
+        )
+
+
+# ---------------------------------------------------------------------------
+# DELETE /tasks/{task_id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/{task_id}", response_model=MessageResponse, responses={404: {}})
+async def cancel_task(
+    task_id: str,
+    user: User = Depends(require_role(Role.admin)),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+    broker: TaskBroker = Depends(get_task_broker),  # noqa: B008
+) -> MessageResponse:
+    with tracer.start_as_current_span(
+        "tasks.cancel",
+        attributes={"user.id": str(user.id), "task.id": task_id},
+    ):
+        stmt = select(TaskSubmission).where(
+            TaskSubmission.id == task_id,
+            TaskSubmission.firm_id == user.firm_id,
+        )
+        result = await db.execute(stmt)
+        sub = result.scalar_one_or_none()
+
+        if sub is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+        await asyncio.to_thread(broker.revoke, task_id, terminate=False)
+
+        sub.status = TaskState.revoked
+        await db.commit()
+        tasks_cancelled.add(1)
+        return MessageResponse(detail="Task revoked")

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -105,7 +105,6 @@ async def submit_task(
             broker.submit, celery_name, body.args, body.kwargs
         )
 
-        now = datetime.now(UTC)
         sub = TaskSubmission(
             id=task_id,
             firm_id=user.firm_id,
@@ -114,7 +113,6 @@ async def submit_task(
             args_json=json.dumps(body.args),
             kwargs_json=json.dumps(body.kwargs),
             status=TaskState.pending,
-            submitted_at=now,
         )
         db.add(sub)
         try:
@@ -138,6 +136,8 @@ async def list_tasks(
     task_name: str | None = Query(None),
     submitted_after: datetime | None = Query(None),  # noqa: B008
     submitted_before: datetime | None = Query(None),  # noqa: B008
+    limit: int = Query(100, ge=1, le=1000),  # noqa: B008
+    offset: int = Query(0, ge=0),  # noqa: B008
     user: User = Depends(get_current_user),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ) -> list[TaskSummary]:
@@ -157,6 +157,7 @@ async def list_tasks(
             stmt = stmt.where(TaskSubmission.submitted_at <= submitted_before)
 
         stmt = stmt.order_by(TaskSubmission.submitted_at.desc())
+        stmt = stmt.limit(limit).offset(offset)
 
         result = await db.execute(stmt)
         return [_submission_to_summary(s) for s in result.scalars().all()]

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -94,3 +94,17 @@ prompts_created = meter.create_counter(
     "opencase.prompts.created",
     description="Prompts submitted",
 )
+
+# ---------------------------------------------------------------------------
+# Tasks (Feature 2.5–2.6)
+# ---------------------------------------------------------------------------
+
+tasks_submitted = meter.create_counter(
+    "opencase.tasks.submitted",
+    description="Tasks submitted via API",
+)
+
+tasks_cancelled = meter.create_counter(
+    "opencase.tasks.cancelled",
+    description="Tasks cancelled via API",
+)

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from fastapi import Depends, HTTPException, status
 from opentelemetry import trace
-from shared.models.enums import Role
+from shared.models.enums import Classification, Role
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -133,13 +133,13 @@ async def build_qdrant_filter(
 
         # Jencks gating — excluded for all non-Admin until Feature 11.1
         # adds witness testimony tracking.
-        excluded.add("jencks")
+        excluded.add(Classification.jencks)
 
         # Work product gating.
         if user.role == Role.investigator or (
             user.role == Role.paralegal and not access_row.view_work_product
         ):
-            excluded.add("work_product")
+            excluded.add(Classification.work_product)
         # Attorney and Paralegal-with-grant: work_product allowed.
 
         return PermissionFilter(

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -6,6 +6,7 @@ from app.db.models.matter import Matter
 from app.db.models.matter_access import MatterAccess
 from app.db.models.prompt import Prompt
 from app.db.models.refresh_token import RefreshToken
+from app.db.models.task_submission import TaskSubmission
 from app.db.models.user import User
 
 __all__ = [
@@ -15,5 +16,6 @@ __all__ = [
     "MatterAccess",
     "Prompt",
     "RefreshToken",
+    "TaskSubmission",
     "User",
 ]

--- a/backend/app/db/models/task_submission.py
+++ b/backend/app/db/models/task_submission.py
@@ -1,0 +1,33 @@
+"""TaskSubmission model — tracks tasks submitted via the API for firm-scoped queries."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from shared.models.enums import TaskState
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class TaskSubmission(Base):
+    __tablename__ = "task_submissions"
+
+    id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    firm_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("firms.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    task_name: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    args_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    kwargs_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=TaskState.pending
+    )
+    submitted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from app.api.health import router as health_router  # noqa: E402
 from app.api.matter_access import router as matter_access_router  # noqa: E402
 from app.api.matters import router as matters_router  # noqa: E402
 from app.api.prompts import router as prompts_router  # noqa: E402
+from app.api.tasks import router as tasks_router  # noqa: E402
 from app.api.users import router as users_router  # noqa: E402
 from app.core.telemetry import configure_instrumentation, setup_telemetry  # noqa: E402
 
@@ -74,5 +75,6 @@ app.include_router(matters_router)
 app.include_router(matter_access_router)
 app.include_router(documents_router)
 app.include_router(prompts_router)
+app.include_router(tasks_router)
 
 configure_instrumentation(app, settings)

--- a/backend/app/workers/broker.py
+++ b/backend/app/workers/broker.py
@@ -1,0 +1,62 @@
+"""TaskBroker — thin abstraction over Celery for submit, status, and revoke.
+
+Keeps the FastAPI layer decoupled from Celery internals so the background
+job backend can be swapped in the future without touching the API router.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from celery import Celery  # type: ignore[import-untyped]
+
+from app.workers import celery_app
+
+
+@dataclass(frozen=True)
+class TaskStatusResult:
+    """Snapshot of a task's current state from the result backend."""
+
+    state: str
+    result: Any | None
+    date_done: datetime | None
+    traceback: str | None
+
+
+class TaskBroker:
+    """Wraps Celery send_task / AsyncResult / control.revoke."""
+
+    def __init__(self, celery: Celery) -> None:
+        self._celery = celery
+
+    def submit(
+        self, celery_task_name: str, args: list[Any], kwargs: dict[str, Any]
+    ) -> str:
+        """Submit a task and return its ID."""
+        result = self._celery.send_task(celery_task_name, args=args, kwargs=kwargs)
+        return str(result.id)
+
+    def get_status(self, task_id: str) -> TaskStatusResult:
+        """Query the result backend for live task state."""
+        r = self._celery.AsyncResult(task_id)
+        return TaskStatusResult(
+            state=r.state,
+            result=r.result,
+            date_done=getattr(r, "date_done", None),
+            traceback=r.traceback,
+        )
+
+    def revoke(self, task_id: str, *, terminate: bool = False) -> None:
+        """Revoke (cancel) a pending or running task."""
+        self._celery.control.revoke(task_id, terminate=terminate)
+
+
+# Singleton — shared across all requests.
+_broker = TaskBroker(celery_app)
+
+
+def get_task_broker() -> TaskBroker:
+    """FastAPI dependency returning the TaskBroker singleton."""
+    return _broker

--- a/backend/app/workers/registry.py
+++ b/backend/app/workers/registry.py
@@ -1,0 +1,9 @@
+"""Task registry — maps user-facing task names to Celery task names.
+
+Only tasks listed here can be submitted via the API. Add new entries as
+tasks are implemented (ingestion, deadline monitor, etc.).
+"""
+
+TASK_REGISTRY: dict[str, str] = {
+    "ping": "opencase.ping",
+}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -32,6 +32,7 @@ from app.db.models.firm import Firm  # noqa: E402
 from app.db.models.matter import Matter  # noqa: E402
 from app.db.models.matter_access import MatterAccess  # noqa: E402
 from app.db.models.refresh_token import RefreshToken  # noqa: E402
+from app.db.models.task_submission import TaskSubmission  # noqa: E402
 from app.db.models.user import User  # noqa: E402
 from app.main import app  # noqa: E402
 
@@ -317,6 +318,7 @@ def seed_admin(postgres_service):
 
     # Teardown — remove all traces.
     with Session(engine) as session:
+        session.execute(delete(TaskSubmission).where(TaskSubmission.user_id == user_id))
         session.execute(delete(RefreshToken).where(RefreshToken.user_id == user_id))
         session.execute(delete(User).where(User.id == user_id))
         session.execute(delete(Firm).where(Firm.id == firm_id))

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from shared.models.enums import MatterStatus, Role
+from shared.models.enums import MatterStatus, Role, TaskState
 
 from app.db.models.firm import Firm
 from app.db.models.matter import Matter
 from app.db.models.matter_access import MatterAccess
+from app.db.models.task_submission import TaskSubmission
 from app.db.models.user import User
 
 
@@ -57,6 +58,21 @@ def make_matter(**kwargs: object) -> Matter:
     }
     defaults.update(kwargs)
     return Matter(**defaults)
+
+
+def make_task_submission(**kwargs: object) -> TaskSubmission:
+    defaults: dict[str, object] = {
+        "id": str(uuid.uuid4()),
+        "firm_id": uuid.uuid4(),
+        "user_id": uuid.uuid4(),
+        "task_name": "ping",
+        "args_json": "[]",
+        "kwargs_json": "{}",
+        "status": TaskState.pending,
+        "submitted_at": datetime.now(UTC),
+    }
+    defaults.update(kwargs)
+    return TaskSubmission(**defaults)
 
 
 def make_matter_access(**kwargs: object) -> MatterAccess:

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -6,9 +6,12 @@ These tests require Docker to be running.
 Run with: pytest -m integration tests/test_integration.py
 """
 
+import asyncio
+
 import httpx
 import pytest
 import redis as redis_lib
+from shared.models.enums import TaskState
 
 
 @pytest.mark.integration
@@ -69,3 +72,48 @@ def test_celery_worker_ping_task(
     )
     result = app.send_task("opencase.ping")
     assert result.get(timeout=15) == "pong"
+
+
+# ---------------------------------------------------------------------------
+# Task API — submit → poll → complete
+# ---------------------------------------------------------------------------
+
+
+async def _login(client: httpx.AsyncClient, email: str, password: str) -> str:
+    """Log in and return an access token."""
+    resp = await client.post("/auth/login", json={"email": email, "password": password})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+@pytest.mark.integration
+async def test_task_submit_poll_complete(
+    fastapi_service: str, seed_admin: dict
+) -> None:
+    """Submit a ping task via the API and poll until it completes."""
+    async with httpx.AsyncClient(base_url=fastapi_service) as client:
+        token = await _login(client, seed_admin["email"], seed_admin["password"])
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Submit
+        resp = await client.post("/tasks/", json={"task_name": "ping"}, headers=headers)
+        assert resp.status_code == 201
+        task_id = resp.json()["task_id"]
+
+        # Poll until SUCCESS (max 15 seconds)
+        for _ in range(30):
+            resp = await client.get(f"/tasks/{task_id}", headers=headers)
+            assert resp.status_code == 200
+            data = resp.json()
+            if data["status"] == TaskState.success:
+                assert data["result"] == "pong"
+                break
+            await asyncio.sleep(0.5)
+        else:
+            pytest.fail(f"Task {task_id} did not complete within 15 seconds")
+
+        # List should include our task
+        resp = await client.get("/tasks/", headers=headers)
+        assert resp.status_code == 200
+        task_ids = [t["id"] for t in resp.json()]
+        assert task_id in task_ids

--- a/backend/tests/test_tasks_api.py
+++ b/backend/tests/test_tasks_api.py
@@ -1,0 +1,282 @@
+"""Unit tests for task CRUD API endpoints.
+
+Uses AsyncClient + in-memory overrides via shared FakeSession / api_client
+from conftest.py.  TaskBroker is replaced with a fake via dependency override.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from shared.models.enums import Role, TaskState
+
+from app.workers.broker import TaskStatusResult, get_task_broker
+from tests.conftest import FakeSession, api_client, auth_header
+from tests.factories import make_task_submission, make_user
+
+# ---------------------------------------------------------------------------
+# Fake broker
+# ---------------------------------------------------------------------------
+
+_FAKE_TASK_ID = str(uuid.uuid4())
+
+
+class FakeBroker:
+    """Stand-in for TaskBroker that records calls."""
+
+    def __init__(
+        self,
+        task_id: str = _FAKE_TASK_ID,
+        state: str = TaskState.pending,
+        result: object = None,
+    ) -> None:
+        self.task_id = task_id
+        self.state = state
+        self.result = result
+        self.submitted: list[tuple[str, list, dict]] = []
+        self.revoked: list[str] = []
+
+    def submit(self, celery_name: str, args: list, kwargs: dict) -> str:
+        self.submitted.append((celery_name, args, kwargs))
+        return self.task_id
+
+    def get_status(self, task_id: str) -> TaskStatusResult:
+        return TaskStatusResult(
+            state=self.state,
+            result=self.result,
+            date_done=datetime.now(UTC) if self.state == TaskState.success else None,
+            traceback=None,
+        )
+
+    def revoke(self, task_id: str, *, terminate: bool = False) -> None:
+        self.revoked.append(task_id)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIRM_ID = uuid.uuid4()
+_NOW = datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# POST /tasks/
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitTask:
+    @pytest.mark.asyncio
+    async def test_submit_returns_201(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        broker = FakeBroker()
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: broker
+            resp = await ac.post(
+                "/tasks/",
+                json={"task_name": "ping"},
+                headers=auth_header(user),
+            )
+        assert resp.status_code == 201
+        assert resp.json()["task_id"] == broker.task_id
+        assert len(broker.submitted) == 1
+        assert broker.submitted[0][0] == "opencase.ping"
+
+    @pytest.mark.asyncio
+    async def test_submit_unknown_task_returns_400(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        broker = FakeBroker()
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: broker
+            resp = await ac.post(
+                "/tasks/",
+                json={"task_name": "nonexistent"},
+                headers=auth_header(user),
+            )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", [Role.paralegal, Role.investigator])
+    async def test_submit_forbidden_for_restricted_roles(self, role: Role) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=role)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: FakeBroker()
+            resp = await ac.post(
+                "/tasks/",
+                json={"task_name": "ping"},
+                headers=auth_header(user),
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_attorney_can_submit(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.attorney)
+        fake = FakeSession()
+        broker = FakeBroker()
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: broker
+            resp = await ac.post(
+                "/tasks/",
+                json={"task_name": "ping"},
+                headers=auth_header(user),
+            )
+        assert resp.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# GET /tasks/
+# ---------------------------------------------------------------------------
+
+
+class TestListTasks:
+    @pytest.mark.asyncio
+    async def test_list_returns_tasks(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        sub = make_task_submission(firm_id=_FIRM_ID, user_id=user.id)
+        fake = FakeSession()
+        fake.add_results_list([sub])
+        async with api_client(user, fake) as ac:
+            resp = await ac.get("/tasks/", headers=auth_header(user))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["task_name"] == "ping"
+
+    @pytest.mark.asyncio
+    async def test_list_empty(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        fake.add_results_list([])
+        async with api_client(user, fake) as ac:
+            resp = await ac.get("/tasks/", headers=auth_header(user))
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /tasks/{task_id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetTask:
+    @pytest.mark.asyncio
+    async def test_get_returns_detail(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        sub = make_task_submission(firm_id=_FIRM_ID, user_id=user.id)
+        fake = FakeSession()
+        fake.add_result(sub)
+        broker = FakeBroker(state=TaskState.success, result="pong")
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: broker
+            resp = await ac.get(f"/tasks/{sub.id}", headers=auth_header(user))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == TaskState.success
+        assert data["result"] == "pong"
+
+    @pytest.mark.asyncio
+    async def test_get_not_found(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        broker = FakeBroker()
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: broker
+            resp = await ac.get(f"/tasks/{uuid.uuid4()}", headers=auth_header(user))
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PUT /tasks/{task_id}  (scaffold)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateTask:
+    @pytest.mark.asyncio
+    async def test_update_returns_200(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        sub = make_task_submission(firm_id=_FIRM_ID, user_id=user.id)
+        fake = FakeSession()
+        fake.add_result(sub)
+        broker = FakeBroker(state=TaskState.pending)
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: broker
+            resp = await ac.put(f"/tasks/{sub.id}", json={}, headers=auth_header(user))
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_update_forbidden_for_non_admin(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.attorney)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: FakeBroker()
+            resp = await ac.put(
+                f"/tasks/{uuid.uuid4()}", json={}, headers=auth_header(user)
+            )
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /tasks/{task_id}
+# ---------------------------------------------------------------------------
+
+
+class TestCancelTask:
+    @pytest.mark.asyncio
+    async def test_cancel_returns_200(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        sub = make_task_submission(firm_id=_FIRM_ID, user_id=user.id)
+        fake = FakeSession()
+        fake.add_result(sub)
+        broker = FakeBroker()
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: broker
+            resp = await ac.delete(f"/tasks/{sub.id}", headers=auth_header(user))
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == "Task revoked"
+        assert sub.id in broker.revoked
+
+    @pytest.mark.asyncio
+    async def test_cancel_forbidden_for_non_admin(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.attorney)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: FakeBroker()
+            resp = await ac.delete(f"/tasks/{uuid.uuid4()}", headers=auth_header(user))
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_cancel_not_found(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        broker = FakeBroker()
+        async with api_client(user, fake) as ac:
+            from app.main import app
+
+            app.dependency_overrides[get_task_broker] = lambda: broker
+            resp = await ac.delete(f"/tasks/{uuid.uuid4()}", headers=auth_header(user))
+        assert resp.status_code == 404

--- a/cli/opencase_cli/commands/documents.py
+++ b/cli/opencase_cli/commands/documents.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 import typer
+from shared.models.enums import Classification, DocumentSource
 
 from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
 from opencase_cli.output import (
@@ -66,10 +67,10 @@ def upload_document(
     file_hash: Annotated[str, typer.Option("--file-hash", help="SHA-256 hex digest.")],
     source: Annotated[
         str, typer.Option("--source", help="Document source.")
-    ] = "defense",
+    ] = DocumentSource.defense,
     classification: Annotated[
         str, typer.Option("--classification", help="Document classification.")
-    ] = "unclassified",
+    ] = Classification.unclassified,
     bates_number: Annotated[
         str | None, typer.Option("--bates-number", help="Bates number.")
     ] = None,

--- a/cli/opencase_cli/commands/tasks.py
+++ b/cli/opencase_cli/commands/tasks.py
@@ -1,0 +1,93 @@
+"""Task management subcommands."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+from shared.models.enums import TaskState
+
+from opencase_cli.common import BaseUrlOption, JsonOption, TimeoutOption, get_client
+from opencase_cli.output import (
+    handle_errors,
+    print_list,
+    print_model,
+    print_success,
+)
+
+app = typer.Typer(help="Background task management.", no_args_is_help=True)
+
+_TASK_COLUMNS = ["id", "task_name", "status", "submitted_at"]
+
+
+@app.command("list")
+def list_tasks(
+    status: Annotated[
+        TaskState | None,
+        typer.Option("--status", help="Filter by task state."),
+    ] = None,
+    task_name: Annotated[
+        str | None,
+        typer.Option("--task-name", help="Filter by task name."),
+    ] = None,
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """List background tasks."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_list(
+            client.list_tasks(status=status, task_name=task_name),
+            columns=_TASK_COLUMNS,
+            json_mode=json_output,
+        )
+
+
+@app.command("get")
+def get_task(
+    task_id: Annotated[str, typer.Argument(help="Task ID.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Get task details by ID."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        print_model(client.get_task(task_id), json_mode=json_output)
+
+
+@app.command("submit")
+def submit_task(
+    task_name: Annotated[
+        str, typer.Option("--task-name", help="Registered task name.")
+    ],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Submit a background task."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        result = client.submit_task(task_name=task_name)
+        if json_output:
+            print_model(result, json_mode=True)
+        else:
+            print_success(f"Task submitted: {result.task_id}")
+
+
+@app.command("cancel")
+def cancel_task(
+    task_id: Annotated[str, typer.Argument(help="Task ID to cancel.")],
+    base_url: BaseUrlOption = None,
+    timeout: TimeoutOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Cancel a pending or running task."""
+    client = get_client(base_url, timeout, authenticated=True)
+    with handle_errors(), client:
+        result = client.cancel_task(task_id)
+        if json_output:
+            print_model(result, json_mode=True)
+        else:
+            print_success(result.detail)

--- a/cli/opencase_cli/main.py
+++ b/cli/opencase_cli/main.py
@@ -17,6 +17,7 @@ from opencase_cli.commands import (
     matters,
     mfa,
     prompts,
+    tasks,
     users,
 )
 from opencase_cli.config import CLIConfig, config_path, load_config, save_config
@@ -40,6 +41,7 @@ app.add_typer(users.app, name="user")
 app.add_typer(matters.app, name="matter")
 app.add_typer(documents.app, name="document")
 app.add_typer(prompts.app, name="prompt")
+app.add_typer(tasks.app, name="task")
 app.add_typer(firms.app, name="firm")
 
 

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -17,10 +17,12 @@ from shared.models.auth import (
     TokenResponse,
 )
 from shared.models.base import MessageResponse
+from shared.models.enums import TaskState
 from shared.models.firm import FirmResponse
 from shared.models.health import HealthResponse, ReadinessResponse, ServiceChecks
 from shared.models.matter import MatterResponse, MatterSummary
 from shared.models.matter_access import MatterAccessResponse
+from shared.models.task import TaskResponse, TaskSubmitResponse, TaskSummary
 from shared.models.user import UserResponse, UserSummary
 from typer.testing import CliRunner
 
@@ -175,3 +177,31 @@ MATTER_ACCESS = MatterAccessResponse(
 )
 
 REVOKE_RESPONSE = MessageResponse(detail="Access revoked")
+
+TASK_SUMMARY = TaskSummary(
+    id="00000000-0000-0000-0000-000000000030",
+    task_name="ping",
+    status=TaskState.pending,
+    submitted_at="2025-01-01T00:00:00",
+    submitted_by="00000000-0000-0000-0000-000000000001",
+)
+
+TASK_RESPONSE = TaskResponse(
+    id="00000000-0000-0000-0000-000000000030",
+    task_name="ping",
+    status=TaskState.success,
+    submitted_at="2025-01-01T00:00:00",
+    submitted_by="00000000-0000-0000-0000-000000000001",
+    firm_id="00000000-0000-0000-0000-000000000002",
+    args=[],
+    kwargs={},
+    result="pong",
+    date_done="2025-01-01T00:00:01",
+    traceback=None,
+)
+
+TASK_SUBMIT_RESPONSE = TaskSubmitResponse(
+    task_id="00000000-0000-0000-0000-000000000030",
+)
+
+TASK_CANCEL_RESPONSE = MessageResponse(detail="Task revoked")

--- a/cli/tests/test_tasks.py
+++ b/cli/tests/test_tasks.py
@@ -1,0 +1,126 @@
+"""Tests for task subcommands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from opencase_cli.main import app
+
+from .conftest import (
+    TASK_CANCEL_RESPONSE,
+    TASK_RESPONSE,
+    TASK_SUBMIT_RESPONSE,
+    TASK_SUMMARY,
+)
+
+_PATCH = "opencase_cli.commands.tasks.get_client"
+_TASK_ID = "00000000-0000-0000-0000-000000000030"
+
+
+class TestListTasks:
+    def test_list_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.list_tasks.return_value = [TASK_SUMMARY]
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["task", "list"])
+        assert result.exit_code == 0
+        assert "ping" in result.output
+
+    def test_list_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.list_tasks.return_value = [TASK_SUMMARY]
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["task", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["task_name"] == "ping"
+
+
+class TestGetTask:
+    def test_get_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_task.return_value = TASK_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["task", "get", _TASK_ID])
+        assert result.exit_code == 0
+        assert "pong" in result.output
+
+    def test_get_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.get_task.return_value = TASK_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["task", "get", _TASK_ID, "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "SUCCESS"
+
+
+class TestSubmitTask:
+    def test_submit_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.submit_task.return_value = TASK_SUBMIT_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["task", "submit", "--task-name", "ping"])
+        assert result.exit_code == 0
+        assert "submitted" in result.output
+
+    def test_submit_json(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.submit_task.return_value = TASK_SUBMIT_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(
+                app, ["task", "submit", "--task-name", "ping", "--json"]
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "task_id" in data
+
+
+class TestCancelTask:
+    def test_cancel_success(
+        self,
+        runner: CliRunner,
+        mock_client: Any,
+        tmp_opencase_dir: Path,
+        stored_tokens: tuple[str, str],
+    ) -> None:
+        mock_client.cancel_task.return_value = TASK_CANCEL_RESPONSE
+        with patch(_PATCH, return_value=mock_client):
+            result = runner.invoke(app, ["task", "cancel", _TASK_ID])
+        assert result.exit_code == 0
+        assert "revoked" in result.output

--- a/sdk/opencase/client.py
+++ b/sdk/opencase/client.py
@@ -16,6 +16,7 @@ from shared.models.document import (
     DocumentResponse,
     DocumentSummary,
 )
+from shared.models.enums import Classification, DocumentSource, TaskState
 from shared.models.firm import FirmResponse
 from shared.models.health import HealthResponse, ReadinessResponse
 from shared.models.matter import (
@@ -28,6 +29,11 @@ from shared.models.matter_access import (
 from shared.models.prompt import (
     PromptResponse,
     PromptSummary,
+)
+from shared.models.task import (
+    TaskResponse,
+    TaskSubmitResponse,
+    TaskSummary,
 )
 from shared.models.user import (
     UserResponse,
@@ -270,8 +276,8 @@ class OpenCaseClient:
         content_type: str,
         size_bytes: int,
         file_hash: str,
-        source: str = "defense",
-        classification: str = "unclassified",
+        source: str = DocumentSource.defense,
+        classification: str = Classification.unclassified,
         bates_number: str | None = None,
     ) -> DocumentResponse:
         payload: dict[str, Any] = {
@@ -303,6 +309,45 @@ class OpenCaseClient:
             "POST", "/prompts/", json={"matter_id": matter_id, "query": query}
         )
         return PromptResponse.model_validate(resp.json())
+
+    # -- tasks ---------------------------------------------------------------
+
+    def list_tasks(
+        self,
+        *,
+        status: TaskState | None = None,
+        task_name: str | None = None,
+    ) -> list[TaskSummary]:
+        params: dict[str, str] = {}
+        if status is not None:
+            params["status"] = status
+        if task_name is not None:
+            params["task_name"] = task_name
+        resp = self._request("GET", "/tasks/", params=params)
+        return [TaskSummary.model_validate(item) for item in resp.json()]
+
+    def get_task(self, task_id: str) -> TaskResponse:
+        resp = self._request("GET", f"/tasks/{task_id}")
+        return TaskResponse.model_validate(resp.json())
+
+    def submit_task(
+        self,
+        *,
+        task_name: str,
+        args: list[Any] | None = None,
+        kwargs: dict[str, Any] | None = None,
+    ) -> TaskSubmitResponse:
+        payload: dict[str, Any] = {"task_name": task_name}
+        if args is not None:
+            payload["args"] = args
+        if kwargs is not None:
+            payload["kwargs"] = kwargs
+        resp = self._request("POST", "/tasks/", json=payload)
+        return TaskSubmitResponse.model_validate(resp.json())
+
+    def cancel_task(self, task_id: str) -> MessageResponse:
+        resp = self._request("DELETE", f"/tasks/{task_id}")
+        return MessageResponse.model_validate(resp.json())
 
     # -- internal transport --------------------------------------------------
 

--- a/sdk/tests/test_task_methods.py
+++ b/sdk/tests/test_task_methods.py
@@ -1,0 +1,141 @@
+"""Unit tests for SDK task methods.
+
+Uses httpx.MockTransport following the pattern in test_entity_methods.py.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import httpx
+from shared.models.base import MessageResponse
+from shared.models.task import TaskResponse, TaskSubmitResponse, TaskSummary
+
+from tests.conftest import build_authenticated_client
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIRM_ID = str(uuid.uuid4())
+_USER_ID = str(uuid.uuid4())
+_TASK_ID = str(uuid.uuid4())
+_NOW = "2025-01-01T00:00:00+00:00"
+
+
+def _task_summary_json(tid: str | None = None) -> dict:
+    return {
+        "id": tid or _TASK_ID,
+        "task_name": "ping",
+        "status": "PENDING",
+        "submitted_at": _NOW,
+        "submitted_by": _USER_ID,
+    }
+
+
+def _task_response_json(tid: str | None = None) -> dict:
+    return {
+        **_task_summary_json(tid),
+        "firm_id": _FIRM_ID,
+        "args": [],
+        "kwargs": {},
+        "result": None,
+        "date_done": None,
+        "traceback": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# list_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_list_tasks() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/tasks/"
+        return httpx.Response(200, json=[_task_summary_json()])
+
+    client = build_authenticated_client(handler)
+    result = client.list_tasks()
+    assert len(result) == 1
+    assert isinstance(result[0], TaskSummary)
+    assert result[0].task_name == "ping"
+
+
+def test_list_tasks_with_filters() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["status"] == "SUCCESS"
+        assert request.url.params["task_name"] == "ping"
+        return httpx.Response(200, json=[])
+
+    client = build_authenticated_client(handler)
+    result = client.list_tasks(status="SUCCESS", task_name="ping")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_task
+# ---------------------------------------------------------------------------
+
+
+def test_get_task() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert f"/tasks/{_TASK_ID}" == request.url.path
+        return httpx.Response(200, json=_task_response_json())
+
+    client = build_authenticated_client(handler)
+    result = client.get_task(_TASK_ID)
+    assert isinstance(result, TaskResponse)
+    assert result.task_name == "ping"
+
+
+# ---------------------------------------------------------------------------
+# submit_task
+# ---------------------------------------------------------------------------
+
+
+def test_submit_task() -> None:
+    sent_body: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/tasks/"
+        assert request.method == "POST"
+        sent_body.update(json.loads(request.content))
+        return httpx.Response(201, json={"task_id": _TASK_ID})
+
+    client = build_authenticated_client(handler)
+    result = client.submit_task(task_name="ping")
+    assert isinstance(result, TaskSubmitResponse)
+    assert result.task_id == _TASK_ID
+    assert sent_body["task_name"] == "ping"
+
+
+def test_submit_task_with_args() -> None:
+    sent_body: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        sent_body.update(json.loads(request.content))
+        return httpx.Response(201, json={"task_id": _TASK_ID})
+
+    client = build_authenticated_client(handler)
+    client.submit_task(task_name="ping", args=[1, 2], kwargs={"key": "val"})
+    assert sent_body["args"] == [1, 2]
+    assert sent_body["kwargs"] == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# cancel_task
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_task() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        assert f"/tasks/{_TASK_ID}" == request.url.path
+        return httpx.Response(200, json={"detail": "Task revoked"})
+
+    client = build_authenticated_client(handler)
+    result = client.cancel_task(_TASK_ID)
+    assert isinstance(result, MessageResponse)
+    assert result.detail == "Task revoked"

--- a/shared/shared/models/__init__.py
+++ b/shared/shared/models/__init__.py
@@ -17,7 +17,13 @@ from shared.models.document import (
     DocumentResponse,
     DocumentSummary,
 )
-from shared.models.enums import Classification, DocumentSource, MatterStatus, Role
+from shared.models.enums import (
+    Classification,
+    DocumentSource,
+    MatterStatus,
+    Role,
+    TaskState,
+)
 from shared.models.firm import FirmResponse
 from shared.models.health import HealthResponse, ReadinessResponse, ServiceChecks
 from shared.models.matter import (
@@ -32,6 +38,13 @@ from shared.models.matter_access import (
     RevokeAccessRequest,
 )
 from shared.models.prompt import CreatePromptRequest, PromptResponse, PromptSummary
+from shared.models.task import (
+    SubmitTaskRequest,
+    TaskResponse,
+    TaskSubmitResponse,
+    TaskSummary,
+    UpdateTaskRequest,
+)
 from shared.models.user import (
     CreateUserRequest,
     UpdateUserRequest,
@@ -70,8 +83,14 @@ __all__ = [
     "RevokeAccessRequest",
     "Role",
     "ServiceChecks",
+    "SubmitTaskRequest",
+    "TaskResponse",
+    "TaskState",
+    "TaskSubmitResponse",
+    "TaskSummary",
     "TokenResponse",
     "UpdateMatterRequest",
+    "UpdateTaskRequest",
     "UpdateUserRequest",
     "UserResponse",
     "UserSummary",

--- a/shared/shared/models/enums.py
+++ b/shared/shared/models/enums.py
@@ -23,6 +23,15 @@ class DocumentSource(enum.StrEnum):
     work_product = "work_product"
 
 
+class TaskState(enum.StrEnum):
+    pending = "PENDING"
+    started = "STARTED"
+    success = "SUCCESS"
+    failure = "FAILURE"
+    revoked = "REVOKED"
+    retry = "RETRY"
+
+
 class Classification(enum.StrEnum):
     brady = "brady"
     giglio = "giglio"

--- a/shared/shared/models/task.py
+++ b/shared/shared/models/task.py
@@ -1,0 +1,57 @@
+"""Pydantic request/response models for task endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from shared.models.enums import TaskState
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class TaskSubmitResponse(BaseModel):
+    """Returned after submitting a task."""
+
+    task_id: str
+
+
+class TaskSummary(BaseModel):
+    """Lightweight task reference (for lists)."""
+
+    id: str
+    task_name: str
+    status: TaskState
+    submitted_at: datetime
+    submitted_by: UUID
+
+
+class TaskResponse(TaskSummary):
+    """Full task detail (single-task endpoint)."""
+
+    firm_id: UUID
+    args: list[Any]
+    kwargs: dict[str, Any]
+    result: Any | None = None
+    date_done: datetime | None = None
+    traceback: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class SubmitTaskRequest(BaseModel):
+    task_name: str = Field(min_length=1, max_length=100)
+    args: list[Any] = Field(default_factory=list)
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
+class UpdateTaskRequest(BaseModel):
+    """Scaffold — no fields are updatable yet."""


### PR DESCRIPTION
## Summary

- Add `/tasks` router with 5 endpoints: submit (POST), list (GET), get (GET), update/scaffold (PUT), cancel (DELETE)
- Tasks submitted asynchronously to Celery via `TaskBroker` abstraction, tracked in firm-scoped `task_submissions` table
- Task whitelist registry prevents arbitrary Celery task invocation
- SDK methods: `list_tasks`, `get_task`, `submit_task`, `cancel_task`
- CLI commands: `task list`, `task get`, `task submit`, `task cancel`
- Replace raw enum strings with `TaskState`/`Classification`/`DocumentSource` across codebase

## Test plan

- [x] 14 backend unit tests (RBAC, submit, list, get, update, cancel, 400/403/404)
- [x] 6 SDK unit tests (list, list with filters, get, submit, submit with args, cancel)
- [x] 7 CLI unit tests (list, list JSON, get, get JSON, submit, submit JSON, cancel)
- [x] Integration test: submit → poll → complete via API (requires Docker)
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, pytest)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)