### PR TITLE
docs: update FEATURES, ERD, CLI, TASKS, and ARCHITECTURE for task CRUD API

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,6 +68,7 @@ backend/
 │   │   ├── auth.py
 │   │   ├── matters.py
 │   │   ├── documents.py
+│   │   ├── tasks.py
 │   │   ├── chatbot.py
 │   │   ├── brady.py
 │   │   └── admin.py
@@ -85,11 +86,11 @@ backend/
 │   │   ├── parser.py         # Tika/Tesseract
 │   │   ├── chunker.py
 │   │   └── deduplicator.py   # SHA-256 dedup
-│   ├── workers/        # Celery tasks
-│   │   ├── cloud_ingest.py
-│   │   ├── deadline.py
-│   │   ├── audit_check.py
-│   │   └── legal_hold.py
+│   ├── workers/        # Celery app + task infrastructure
+│   │   ├── broker.py         # TaskBroker abstraction
+│   │   ├── registry.py       # TASK_REGISTRY whitelist
+│   │   └── tasks/
+│   │       └── ping.py       # Health-check task
 │   └── db/             # Database layer
 │       ├── models.py
 │       └── session.py
@@ -142,6 +143,25 @@ flowchart TD
     I -->|vectors + permission payload| J[Record in PostgreSQL]
     J -->|metadata + audit log entry| K[Done]
 ```
+
+## Data Flow: Task Submission
+
+```mermaid
+flowchart TD
+    A[Client — CLI / SDK / API call] --> B[POST /tasks/]
+    B --> C{task_name in TASK_REGISTRY?}
+    C -->|no| D[400 Bad Request]
+    C -->|yes| E[TaskBroker.submit]
+    E -->|send_task| F[Redis broker]
+    E --> G[Record in task_submissions table]
+    F --> H[Celery Worker executes task]
+    H --> I[Result → opencase_tasks DB]
+    G --> J[Client polls GET /tasks/task_id]
+    J -->|live enrichment| I
+    J --> K[Response with status + result]
+```
+
+---
 
 ## Document Storage
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -94,6 +94,23 @@ opencase matter access-grant <matter-id> --user-id <uuid> --view-work-product
 opencase matter access-revoke <matter-id> --user-id <uuid>
 ```
 
+### Tasks
+
+```bash
+opencase task list                          # list all tasks for current firm
+opencase task list --status pending         # filter by state
+opencase task list --task-name ping         # filter by registered task name
+opencase task get <task-id>                 # full task detail + live Celery status
+opencase task submit --task-name ping       # submit a registered task
+opencase task cancel <task-id>              # revoke a pending/running task
+```
+
+Task submission requires Admin or Attorney role. Cancel and update
+require Admin. List and get are available to any authenticated user.
+
+Only tasks registered in `TASK_REGISTRY` can be submitted via the
+API. Currently registered: `ping`.
+
 ### Documents (stub)
 
 ```bash

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,10 +1,10 @@
 # OpenCase — Entity Relationship Diagram
 
-Covers the tables introduced in Feature 1.2. Tables from later features
-(documents, audit_log, witnesses, disclosure_checklist, etc.) will be added
+Covers tables through Feature 2.6. Tables from later features
+(audit_log, witnesses, disclosure_checklist, etc.) will be added
 as each feature lands.
 
-## Feature 1 — Core Schema
+## Core + Worker Queue Schema
 
 ```mermaid
 erDiagram
@@ -80,6 +80,17 @@ erDiagram
         timestamptz updated_at
     }
 
+    task_submissions {
+        string id PK "Celery task ID"
+        uuid firm_id FK
+        uuid user_id FK
+        string task_name "registered name — e.g. ping"
+        text args_json "JSON array of positional args"
+        text kwargs_json "JSON object of keyword args"
+        string status "TaskState enum — pending | started | success | failure | revoked | retry"
+        timestamptz submitted_at
+    }
+
     firms ||--o{ users : "has"
     firms ||--o{ matters : "owns"
     firms ||--o{ documents : "scoped to"
@@ -90,6 +101,8 @@ erDiagram
     matters ||--o{ prompts : "queried within"
     users ||--o{ documents : "uploaded by"
     users ||--o{ prompts : "created by"
+    firms ||--o{ task_submissions : "scoped to"
+    users ||--o{ task_submissions : "submitted by"
 ```
 
 ## Key Constraints
@@ -109,6 +122,10 @@ erDiagram
 | `prompts` | `fk_prompts_firm_id_firms` | Cascades on firm delete |
 | `prompts` | `fk_prompts_matter_id_matters` | Cascades on matter delete |
 | `prompts` | `fk_prompts_created_by_users` | Cascades on user delete |
+| `task_submissions` | `fk_task_submissions_firm_id_firms` | Cascades on firm delete |
+| `task_submissions` | `fk_task_submissions_user_id_users` | Cascades on user delete |
+| `task_submissions` | `ix_task_submissions_firm_id` | Index on `firm_id` for firm-scoped queries |
+| `task_submissions` | `ix_task_submissions_task_name` | Index on `task_name` for filtering |
 
 ## Notes
 
@@ -126,3 +143,7 @@ erDiagram
   permission model, not operator-configurable data.
 - `client_id` is a UUID reference to a client record. The clients table will be
   introduced in a later feature; for now it is stored as a bare UUID.
+- `task_submissions.id` is the Celery task ID (a string, not a UUID). The
+  primary key is assigned by Celery at submission time.
+- `task_submissions.status` is denormalized from the Celery result backend and
+  updated on read via `GET /tasks/{task_id}`.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -35,8 +35,8 @@
 | 2.2 | Redis broker + Celery worker + Beat containers (Dockerfile, health checks, env wiring) | Done | Done | Done |
 | 2.3 | Celery app + task definitions (app/workers/) | Done | Done | Done |
 | 2.4 | Task result persistence (opencase_tasks DB on shared Postgres, Celery DB backend) | Done | Done | Done |
-| 2.5 | API integration (Celery client, task.delay() submission) | Pending | Pending | Pending |
-| 2.6 | Task status API endpoint (read-only — query task progress/result by task ID for API-triggered tasks) | Pending | Pending | Pending |
+| 2.5 | API integration (Celery client, task.delay() submission) | Done | Done | Done |
+| 2.6 | Task status API endpoint (read-only — query task progress/result by task ID for API-triggered tasks) | Done | Done | Done |
 | 2.7 | Observability (Flower container + OTel Celery instrumentation) | Pending | Pending | Pending |
 
 ## Feature 3 — S3 Storage

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -10,11 +10,11 @@ embedding, deadline monitoring) do not block API responses.
 ## Architecture
 
 ```text
-FastAPI  ──task.delay()──▶  Redis (broker)  ──▶  Celery Worker
-                                                      │
-                                                      ▼
-                                                 PostgreSQL
-                                              (opencase_tasks)
+FastAPI  ──TaskBroker.submit()──▶  Redis (broker)  ──▶  Celery Worker
+  │                                                          │
+  ▼                                                          ▼
+PostgreSQL (main)                                       PostgreSQL
+(task_submissions)                                   (opencase_tasks)
 ```
 
 | Component | Role |
@@ -26,14 +26,15 @@ FastAPI  ──task.delay()──▶  Redis (broker)  ──▶  Celery Worker
 
 ### How a task runs
 
-1. API code calls `task_name.delay(args)` — this serializes the call as
-   JSON and pushes it onto a Redis queue.
+1. API code calls `TaskBroker.submit()` — this serializes the call as
+   JSON and pushes it onto a Redis queue. A `task_submissions` row is
+   recorded in the main database for firm-scoped tracking.
 2. The Celery worker pulls the message, deserializes it, and calls the
    Python function.
 3. On completion (or failure), the result is written to the
    `opencase_tasks` database. The caller can poll the result by task ID.
-4. The original API endpoint can return immediately with the task ID,
-   then the client polls a status endpoint (Feature 2.6).
+4. The original API endpoint returns immediately with the task ID.
+   The client polls `GET /tasks/{task_id}` to check progress.
 
 ### Celery Beat (scheduler)
 
@@ -80,7 +81,64 @@ bound to whichever app finalizes first.
 
 ---
 
-## Task Registry
+## API Endpoints
+
+Task management is exposed via REST endpoints on `/tasks/`. All
+endpoints are firm-scoped — users only see tasks submitted by their
+firm.
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| `POST` | `/tasks/` | Admin, Attorney | Submit a registered task |
+| `GET` | `/tasks/` | Any authenticated | List tasks (filters: status, task_name, date range) |
+| `GET` | `/tasks/{task_id}` | Any authenticated | Full detail + live Celery status |
+| `PUT` | `/tasks/{task_id}` | Admin | Update (scaffold — no updatable fields yet) |
+| `DELETE` | `/tasks/{task_id}` | Admin | Cancel a pending/running task |
+
+`GET /tasks/{task_id}` enriches the response with live state from the
+Celery result backend and denormalizes the status back to the
+`task_submissions` table.
+
+---
+
+## TaskBroker
+
+[`app/workers/broker.py`](../backend/app/workers/broker.py) provides a
+thin abstraction over Celery so the API layer is decoupled from Celery
+internals. This allows the background job backend to be swapped in the
+future without touching the API router.
+
+| Method | Signature | Purpose |
+| --- | --- | --- |
+| `submit` | `(celery_task_name, args, kwargs) → str` | Send task to broker, return task ID |
+| `get_status` | `(task_id) → TaskStatusResult` | Query result backend for live state |
+| `revoke` | `(task_id, *, terminate=False) → None` | Cancel a pending or running task |
+
+`get_task_broker()` is the FastAPI dependency that returns the
+singleton `TaskBroker` instance.
+
+---
+
+## Task Registry (Whitelist)
+
+[`app/workers/registry.py`](../backend/app/workers/registry.py)
+defines `TASK_REGISTRY` — a dict mapping user-facing task names to
+Celery task names. **Only tasks listed here can be submitted via the
+API.** This is a security boundary: arbitrary Celery task names cannot
+be invoked by API callers.
+
+```python
+TASK_REGISTRY: dict[str, str] = {
+    "ping": "opencase.ping",
+}
+```
+
+To make a new task submittable via the API, add an entry here in
+addition to creating the task module (see "Adding a New Task" below).
+
+---
+
+## Registered Tasks
 
 ### `opencase.ping`
 
@@ -140,13 +198,14 @@ Tasks will be added as features are built:
 3. Use an explicit `name=` parameter. This decouples the task identity
    from the module path, so refactoring does not break in-flight tasks.
 
-4. Call from the API:
+4. Add the task to `TASK_REGISTRY` in `app/workers/registry.py` so it
+   can be submitted via the API:
 
     ```python
-    from app.workers.tasks.my_task import my_task
-
-    result = my_task.delay("some_arg")
-    # result.id is the task ID for status polling
+    TASK_REGISTRY: dict[str, str] = {
+        "ping": "opencase.ping",
+        "my_task": "opencase.my_task",
+    }
     ```
 
 5. Add unit tests in `backend/tests/test_workers.py` to verify the task


### PR DESCRIPTION
## Summary

- **FEATURES.md** — Mark Features 2.5 and 2.6 as Done (Specs/Code/Docs)
- **ERD.md** — Add `task_submissions` table schema, FK relationships, indexes, and notes
- **CLI.md** — Add `task` command group (list, get, submit, cancel) with RBAC notes
- **TASKS.md** — Add API endpoints table, TaskBroker abstraction, Task Registry whitelist; update architecture diagram and "Adding a New Task" guide
- **ARCHITECTURE.md** — Add task submission data flow diagram; update module structure and API routers list

## Test plan

- [x] All five `.md` files pass `markdownlint`
- [x] Mermaid diagrams render correctly on GitHub (ERD + task submission flow)
- [x] Cross-references between docs resolve (TASKS.md → broker.py, registry.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)