### PR TITLE
feat: S3 document upload, download, and dedup via MinIO (#32)

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -1,24 +1,43 @@
-"""Document router — stub endpoints for document management."""
+"""Document router — upload, list, retrieve, and download documents."""
 
 from __future__ import annotations
 
+import logging
+import re
 import uuid
-from datetime import UTC, datetime
+from pathlib import PurePosixPath
+from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from opentelemetry import trace
-from shared.models.document import (
-    CreateDocumentRequest,
-    DocumentResponse,
-    DocumentSummary,
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    UploadFile,
+    status,
 )
+from fastapi.responses import Response
+from opentelemetry import trace
+from shared.models.document import DocumentResponse, DocumentSummary
+from shared.models.enums import Classification, DocumentSource, Role
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
-from app.core.metrics import documents_created
+from app.core.metrics import documents_created, documents_duplicates_rejected
+from app.core.permissions import fetch_matter_access
 from app.db import get_db
+from app.db.models.document import Document
+from app.db.models.matter_access import MatterAccess
 from app.db.models.user import User
+from app.storage import get_storage_service
+from app.storage.hashing import FileTooLargeError, read_and_hash
+from app.storage.s3 import S3StorageService
 
+logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
 router = APIRouter(prefix="/documents", tags=["documents"])
@@ -29,28 +48,108 @@ router = APIRouter(prefix="/documents", tags=["documents"])
 # ---------------------------------------------------------------------------
 
 
-def _stub_document_response(
-    doc_id: uuid.UUID,
-    body: CreateDocumentRequest,
-    user: User,
-) -> DocumentResponse:
-    now = datetime.now(UTC)
+_ALLOWED_CONTENT_TYPES = frozenset(
+    {
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/rtf",
+        "text/plain",
+        "text/csv",
+        "text/html",
+        "image/jpeg",
+        "image/png",
+        "image/tiff",
+        "image/gif",
+        "image/bmp",
+        "image/webp",
+        "application/octet-stream",
+    }
+)
+
+_SAFE_FILENAME_RE = re.compile(r"[^\w\s\-.,()]+")
+
+
+def _sanitize_filename(filename: str | None) -> str:
+    """Strip path components and dangerous characters from a filename."""
+    if not filename:
+        return "unnamed"
+    # Take only the final path component (strip directory traversal)
+    name = PurePosixPath(filename).name
+    # Remove characters that aren't word chars, spaces, hyphens, dots, commas, or parens
+    name = _SAFE_FILENAME_RE.sub("_", name)
+    # Collapse runs of underscores
+    name = re.sub(r"_+", "_", name).strip("_")
+    return name or "unnamed"
+
+
+def _extension_from_filename(filename: str | None) -> str:
+    """Extract the file extension (without dot) from a filename."""
+    if not filename:
+        return "bin"
+    suffix = PurePosixPath(filename).suffix
+    return suffix.lstrip(".").lower() if suffix else "bin"
+
+
+def _doc_to_response(doc: Document) -> DocumentResponse:
     return DocumentResponse(
-        id=doc_id,
-        firm_id=user.firm_id,
-        matter_id=body.matter_id,
-        filename=body.filename,
-        content_type=body.content_type,
-        size_bytes=body.size_bytes,
-        source=body.source,
-        classification=body.classification,
-        legal_hold=False,
-        file_hash=body.file_hash,
-        bates_number=body.bates_number,
-        uploaded_by=user.id,
-        created_at=now,
-        updated_at=now,
+        id=doc.id,
+        firm_id=doc.firm_id,
+        matter_id=doc.matter_id,
+        filename=doc.filename,
+        content_type=doc.content_type,
+        size_bytes=doc.size_bytes,
+        source=doc.source,
+        classification=doc.classification,
+        legal_hold=doc.legal_hold,
+        file_hash=doc.file_hash,
+        bates_number=doc.bates_number,
+        uploaded_by=doc.uploaded_by,
+        created_at=doc.created_at,
+        updated_at=doc.updated_at,
     )
+
+
+def _doc_to_summary(doc: Document) -> DocumentSummary:
+    return DocumentSummary(
+        id=doc.id,
+        filename=doc.filename,
+        content_type=doc.content_type,
+        size_bytes=doc.size_bytes,
+        source=doc.source,
+        classification=doc.classification,
+        legal_hold=doc.legal_hold,
+        matter_id=doc.matter_id,
+    )
+
+
+async def _verify_matter_access(
+    matter_id: uuid.UUID, user: User, db: AsyncSession
+) -> None:
+    """Check matter access for non-admin users. Raises 404 on failure."""
+    if user.role == Role.admin:
+        return
+    await fetch_matter_access(matter_id, user, db)
+
+
+async def _get_document_with_access(
+    document_id: uuid.UUID, user: User, db: AsyncSession
+) -> Document:
+    """Fetch a document by ID with firm-scope and matter access check."""
+    result = await db.execute(
+        select(Document).where(
+            Document.id == document_id,
+            Document.firm_id == user.firm_id,
+        )
+    )
+    doc = result.scalar_one_or_none()
+    if doc is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    await _verify_matter_access(doc.matter_id, user, db)
+    return doc
 
 
 # ---------------------------------------------------------------------------
@@ -64,21 +163,123 @@ def _stub_document_response(
     status_code=status.HTTP_201_CREATED,
 )
 async def create_document(
-    body: CreateDocumentRequest,
+    file: UploadFile = File(...),  # noqa: B008
+    matter_id: uuid.UUID = Form(...),  # noqa: B008
+    source: DocumentSource = Form(DocumentSource.defense),  # noqa: B008
+    classification: Classification = Form(Classification.unclassified),  # noqa: B008
+    bates_number: str | None = Form(None),  # noqa: B008
     user: User = Depends(get_current_user),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
+    storage: S3StorageService = Depends(get_storage_service),  # noqa: B008
 ) -> DocumentResponse:
-    """Stub — accepts document metadata and returns a canned response.
+    """Upload a document to a matter.
 
-    Future: will compute SHA-256, store file in MinIO, and save metadata.
+    Accepts a multipart form with the file and metadata fields. The server
+    computes the SHA-256 hash and checks for duplicates within the matter.
     """
     with tracer.start_as_current_span(
         "documents.create",
-        attributes={"user.id": str(user.id), "matter.id": str(body.matter_id)},
+        attributes={"user.id": str(user.id), "matter.id": str(matter_id)},
     ):
+        # 1. Verify matter access
+        await _verify_matter_access(matter_id, user, db)
+
+        # 2. Validate content type
+        content_type = file.content_type or "application/octet-stream"
+        if content_type not in _ALLOWED_CONTENT_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+                detail=f"Content type '{content_type}' is not allowed",
+            )
+
+        # 3. Read file + compute SHA-256
+        try:
+            data, file_hash, size_bytes = await read_and_hash(file)
+        except FileTooLargeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=str(exc),
+            ) from exc
+
+        # 4. Dedup check via DB unique constraint
         doc_id = uuid.uuid4()
+        filename = _sanitize_filename(file.filename)
+        extension = _extension_from_filename(file.filename)
+
+        doc = Document(
+            id=doc_id,
+            firm_id=user.firm_id,
+            matter_id=matter_id,
+            filename=filename,
+            file_hash=file_hash,
+            content_type=content_type,
+            size_bytes=size_bytes,
+            source=source,
+            classification=classification,
+            bates_number=bates_number,
+            legal_hold=False,
+            uploaded_by=user.id,
+        )
+        db.add(doc)
+
+        try:
+            await db.flush()
+        except IntegrityError as exc:
+            await db.rollback()
+            documents_duplicates_rejected.add(1)
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="A document with the same content already exists in this matter",
+            ) from exc
+
+        # 4. Upload to S3
+        try:
+            s3_key = await storage.upload_document(
+                firm_id=user.firm_id,
+                matter_id=matter_id,
+                document_id=doc_id,
+                extension=extension,
+                data=data,
+                size=size_bytes,
+                content_type=content_type,
+                file_hash=file_hash,
+            )
+        except Exception as exc:
+            await db.rollback()
+            logger.exception("S3 upload failed for document %s", doc_id)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to store file in object storage",
+            ) from exc
+
+        # 6. Commit DB transaction (clean up S3 object on failure)
+        try:
+            await db.commit()
+        except Exception:
+            logger.exception(
+                "DB commit failed for document %s; removing S3 object",
+                doc_id,
+            )
+            await storage.delete_document(s3_key)
+            raise
+        await db.refresh(doc)
+
+        # 6. Fire-and-forget ingestion task
+        try:
+            from app.ingestion import get_ingestion_service
+
+            ingestion = get_ingestion_service()
+            await ingestion.process_document(doc_id, s3_key)
+        except Exception:
+            # Ingestion failure must not block the upload response.
+            # The document is already persisted — ingestion can be
+            # retried later.
+            logger.exception("Ingestion dispatch failed for document %s", doc_id)
+
         documents_created.add(1)
-        return _stub_document_response(doc_id, body, user)
+        logger.info("Document uploaded: id=%s key=%s", doc_id, s3_key)
+
+        return _doc_to_response(doc)
 
 
 # ---------------------------------------------------------------------------
@@ -88,15 +289,36 @@ async def create_document(
 
 @router.get("/", response_model=list[DocumentSummary])
 async def list_documents(
+    matter_id: uuid.UUID | None = Query(None),  # noqa: B008
     user: User = Depends(get_current_user),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ) -> list[DocumentSummary]:
-    """Stub — returns an empty list."""
+    """List documents accessible to the current user.
+
+    Optionally filter by ``matter_id``. Non-admin users only see documents
+    in matters they have been granted access to.
+    """
     with tracer.start_as_current_span(
         "documents.list",
         attributes={"user.id": str(user.id)},
     ):
-        return []
+        stmt = select(Document).where(Document.firm_id == user.firm_id)
+
+        if matter_id is not None:
+            await _verify_matter_access(matter_id, user, db)
+            stmt = stmt.where(Document.matter_id == matter_id)
+        elif user.role != Role.admin:
+            # Non-admin without explicit matter_id: scope to accessible matters
+            stmt = stmt.join(
+                MatterAccess,
+                (MatterAccess.matter_id == Document.matter_id)
+                & (MatterAccess.user_id == user.id),
+            )
+
+        stmt = stmt.order_by(Document.created_at.desc())
+        result = await db.execute(stmt)
+        docs = result.scalars().all()
+        return [_doc_to_summary(d) for d in docs]
 
 
 # ---------------------------------------------------------------------------
@@ -110,9 +332,56 @@ async def get_document(
     user: User = Depends(get_current_user),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
 ) -> DocumentResponse:
-    """Stub — always returns 404."""
+    """Retrieve metadata for a single document."""
     with tracer.start_as_current_span(
         "documents.get",
         attributes={"user.id": str(user.id), "document.id": str(document_id)},
     ):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+        doc = await _get_document_with_access(document_id, user, db)
+        return _doc_to_response(doc)
+
+
+# ---------------------------------------------------------------------------
+# GET /documents/{document_id}/download
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{document_id}/download",
+    responses={404: {}, 502: {}},
+)
+async def download_document(
+    document_id: uuid.UUID,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+    storage: S3StorageService = Depends(get_storage_service),  # noqa: B008
+) -> Response:
+    """Download the original file for a document."""
+    with tracer.start_as_current_span(
+        "documents.download",
+        attributes={"user.id": str(user.id), "document.id": str(document_id)},
+    ):
+        doc = await _get_document_with_access(document_id, user, db)
+
+        extension = _extension_from_filename(doc.filename)
+        s3_key = S3StorageService.object_key(
+            doc.firm_id, doc.matter_id, doc.id, extension
+        )
+
+        try:
+            file_bytes, _ct = await storage.download_document(s3_key)
+        except Exception as exc:
+            logger.exception("S3 download failed for document %s", document_id)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to retrieve file from object storage",
+            ) from exc
+
+        encoded_name = quote(doc.filename, safe="")
+        return Response(
+            content=file_bytes,
+            media_type=doc.content_type,
+            headers={
+                "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_name}",
+            },
+        )

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -232,7 +232,7 @@ async def create_document(
                 detail="A document with the same content already exists in this matter",
             ) from exc
 
-        # 4. Upload to S3
+        # 5. Upload to S3
         try:
             s3_key = await storage.upload_document(
                 firm_id=user.firm_id,
@@ -255,16 +255,23 @@ async def create_document(
         # 6. Commit DB transaction (clean up S3 object on failure)
         try:
             await db.commit()
-        except Exception:
+        except Exception as commit_exc:
             logger.exception(
                 "DB commit failed for document %s; removing S3 object",
                 doc_id,
             )
-            await storage.delete_document(s3_key)
-            raise
+            try:
+                await storage.delete_document(s3_key)
+            except Exception:
+                logger.exception(
+                    "S3 cleanup also failed for document %s, key %s",
+                    doc_id,
+                    s3_key,
+                )
+            raise commit_exc
         await db.refresh(doc)
 
-        # 6. Fire-and-forget ingestion task
+        # 7. Fire-and-forget ingestion task
         try:
             from app.ingestion import get_ingestion_service
 
@@ -378,10 +385,14 @@ async def download_document(
             ) from exc
 
         encoded_name = quote(doc.filename, safe="")
+        ascii_name = doc.filename.encode("ascii", "replace").decode()
         return Response(
             content=file_bytes,
             media_type=doc.content_type,
             headers={
-                "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_name}",
+                "Content-Disposition": (
+                    f'attachment; filename="{ascii_name}"; '
+                    f"filename*=UTF-8''{encoded_name}"
+                ),
             },
         )

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -86,6 +86,11 @@ documents_created = meter.create_counter(
     description="Documents created",
 )
 
+documents_duplicates_rejected = meter.create_counter(
+    "opencase.documents.duplicates_rejected",
+    description="Duplicate document upload rejections",
+)
+
 # ---------------------------------------------------------------------------
 # Prompts (Feature 1.8)
 # ---------------------------------------------------------------------------

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -50,13 +50,13 @@ class PermissionFilter:
 
 
 # ---------------------------------------------------------------------------
-# _fetch_matter_access — private helper shared by build_qdrant_filter and
-# require_matter_access. Separated from FastAPI DI so callers can invoke it
-# directly without going through Depends().
+# fetch_matter_access — shared helper used by build_qdrant_filter,
+# require_matter_access, and the document router. Separated from FastAPI DI
+# so callers can invoke it directly without going through Depends().
 # ---------------------------------------------------------------------------
 
 
-async def _fetch_matter_access(
+async def fetch_matter_access(
     matter_id: uuid.UUID,
     user: User,
     db: AsyncSession,
@@ -129,7 +129,7 @@ async def build_qdrant_filter(
             )
 
         # Non-admin: verify MatterAccess row exists with firm-scope join.
-        access_row = await _fetch_matter_access(matter_id, user, db)
+        access_row = await fetch_matter_access(matter_id, user, db)
 
         # Jencks gating — excluded for all non-Admin until Feature 11.1
         # adds witness testimony tracking.
@@ -198,7 +198,7 @@ async def require_matter_access(
 ) -> MatterAccess | None:
     """Verify the user has access to the given matter.
 
-    Thin FastAPI dependency wrapper around ``_fetch_matter_access``.
+    Thin FastAPI dependency wrapper around ``fetch_matter_access``.
 
     Returns:
         ``MatterAccess`` for non-admin users (always — a missing row
@@ -218,4 +218,4 @@ async def require_matter_access(
         if user.role == Role.admin:
             return None
 
-        return await _fetch_matter_access(matter_id, user, db)
+        return await fetch_matter_access(matter_id, user, db)

--- a/backend/app/ingestion/__init__.py
+++ b/backend/app/ingestion/__init__.py
@@ -1,0 +1,20 @@
+"""Ingestion module — document processing pipeline."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.ingestion.service import IngestionService
+
+_service: IngestionService | None = None
+
+
+def get_ingestion_service() -> IngestionService:
+    """FastAPI dependency returning the IngestionService singleton."""
+    global _service  # noqa: PLW0603
+    if _service is None:
+        from app.ingestion.service import IngestionService
+
+        _service = IngestionService()
+    return _service

--- a/backend/app/ingestion/service.py
+++ b/backend/app/ingestion/service.py
@@ -1,0 +1,36 @@
+"""Stub ingestion workflow — placeholder for the full pipeline.
+
+Future features will extend this with:
+- Text extraction via Apache Tika + Tesseract OCR
+- Chunking and overlap strategy
+- Embedding via Ollama (nomic-embed-text)
+- Vector storage in Qdrant with permission payload
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+logger = logging.getLogger(__name__)
+
+
+class IngestionService:
+    """Orchestrates the document ingestion pipeline.
+
+    Currently a stub that logs the request. The full pipeline will
+    download from S3, extract text, chunk, embed, and store vectors.
+    """
+
+    async def process_document(self, document_id: uuid.UUID, s3_key: str) -> None:
+        """Kick off ingestion for a newly uploaded document.
+
+        Args:
+            document_id: The document's primary key.
+            s3_key: The S3 object key where the original file is stored.
+        """
+        logger.info(
+            "Ingestion stub: document_id=%s s3_key=%s (pipeline not yet implemented)",
+            document_id,
+            s3_key,
+        )

--- a/backend/app/storage/__init__.py
+++ b/backend/app/storage/__init__.py
@@ -1,0 +1,21 @@
+"""Storage module — S3-compatible object storage via MinIO."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.storage.s3 import S3StorageService
+
+_service: S3StorageService | None = None
+
+
+def get_storage_service() -> S3StorageService:
+    """FastAPI dependency returning the S3StorageService singleton."""
+    global _service  # noqa: PLW0603
+    if _service is None:
+        from app.core.config import settings
+        from app.storage.s3 import S3StorageService
+
+        _service = S3StorageService(settings.s3)
+    return _service

--- a/backend/app/storage/hashing.py
+++ b/backend/app/storage/hashing.py
@@ -1,0 +1,46 @@
+"""Chunked SHA-256 hashing for uploaded files with size enforcement."""
+
+from __future__ import annotations
+
+import hashlib
+from io import BytesIO
+
+from fastapi import UploadFile
+
+_CHUNK_SIZE = 64 * 1024  # 64 KB
+_MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
+
+
+class FileTooLargeError(Exception):
+    """Raised when an uploaded file exceeds the size limit."""
+
+
+async def read_and_hash(
+    upload_file: UploadFile,
+    *,
+    max_bytes: int = _MAX_UPLOAD_BYTES,
+) -> tuple[BytesIO, str, int]:
+    """Read an ``UploadFile`` in chunks, compute its SHA-256, and enforce a size limit.
+
+    Returns:
+        A tuple of ``(data, hex_digest, size_bytes)`` where *data* is a
+        :class:`~io.BytesIO` seeked to position 0.
+
+    Raises:
+        FileTooLargeError: If the file exceeds *max_bytes*.
+    """
+    hasher = hashlib.sha256()
+    buf = BytesIO()
+    total = 0
+
+    while chunk := await upload_file.read(_CHUNK_SIZE):
+        total += len(chunk)
+        if total > max_bytes:
+            raise FileTooLargeError(
+                f"File exceeds maximum allowed size of {max_bytes} bytes"
+            )
+        hasher.update(chunk)
+        buf.write(chunk)
+
+    buf.seek(0)
+    return buf, hasher.hexdigest(), total

--- a/backend/app/storage/s3.py
+++ b/backend/app/storage/s3.py
@@ -1,0 +1,148 @@
+"""S3StorageService — async wrapper around minio-py for document storage."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from io import BytesIO
+
+from minio import Minio
+from opentelemetry import trace
+
+from app.core.config import S3Settings
+
+tracer = trace.get_tracer(__name__)
+
+
+class S3StorageService:
+    """Wraps minio-py with the OpenCase bucket layout convention.
+
+    Bucket key pattern::
+
+        {firm_id}/{matter_id}/{document_id}/original.{ext}
+    """
+
+    def __init__(self, s3_settings: S3Settings) -> None:
+        self._client = Minio(
+            s3_settings.endpoint,
+            access_key=s3_settings.access_key,
+            secret_key=s3_settings.secret_key,
+            secure=s3_settings.use_ssl,
+            region=s3_settings.region,
+        )
+        self._bucket = s3_settings.bucket
+
+    # ------------------------------------------------------------------
+    # Key construction
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def object_key(
+        firm_id: uuid.UUID,
+        matter_id: uuid.UUID,
+        document_id: uuid.UUID,
+        extension: str,
+    ) -> str:
+        """Build the canonical S3 object key for a document."""
+        return f"{firm_id}/{matter_id}/{document_id}/original.{extension}"
+
+    # ------------------------------------------------------------------
+    # Upload
+    # ------------------------------------------------------------------
+
+    async def upload_document(
+        self,
+        *,
+        firm_id: uuid.UUID,
+        matter_id: uuid.UUID,
+        document_id: uuid.UUID,
+        extension: str,
+        data: BytesIO,
+        size: int,
+        content_type: str,
+        file_hash: str,
+    ) -> str:
+        """Upload a document to MinIO. Returns the object key."""
+        with tracer.start_as_current_span(
+            "s3.upload_document",
+            attributes={
+                "document.id": str(document_id),
+                "s3.bucket": self._bucket,
+                "s3.size_bytes": size,
+            },
+        ):
+            key = self.object_key(firm_id, matter_id, document_id, extension)
+            metadata = {
+                "document-id": str(document_id),
+                "matter-id": str(matter_id),
+                "sha256": file_hash,
+                "ingestion-timestamp": datetime.now(UTC).isoformat(),
+            }
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                None,
+                self._put_object,
+                key,
+                data,
+                size,
+                content_type,
+                metadata,
+            )
+            return key
+
+    def _put_object(
+        self,
+        key: str,
+        data: BytesIO,
+        size: int,
+        content_type: str,
+        metadata: dict[str, str],
+    ) -> None:
+        self._client.put_object(
+            self._bucket,
+            key,
+            data,
+            length=size,
+            content_type=content_type,
+            metadata=metadata,  # type: ignore[arg-type]  # minio expects wider union
+        )
+
+    # ------------------------------------------------------------------
+    # Download
+    # ------------------------------------------------------------------
+
+    async def download_document(self, key: str) -> tuple[bytes, str]:
+        """Download a document from MinIO. Returns ``(file_bytes, content_type)``."""
+        with tracer.start_as_current_span(
+            "s3.download_document",
+            attributes={"s3.key": key, "s3.bucket": self._bucket},
+        ):
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, self._get_object, key)
+
+    def _get_object(self, key: str) -> tuple[bytes, str]:
+        response = self._client.get_object(self._bucket, key)
+        try:
+            data = response.read()
+            ct = response.headers.get("Content-Type", "application/octet-stream")
+        finally:
+            response.close()
+            response.release_conn()
+        return data, ct
+
+    # ------------------------------------------------------------------
+    # Delete (cleanup on failed commits)
+    # ------------------------------------------------------------------
+
+    async def delete_document(self, key: str) -> None:
+        """Delete an object from MinIO."""
+        with tracer.start_as_current_span(
+            "s3.delete_document",
+            attributes={"s3.key": key, "s3.bucket": self._bucket},
+        ):
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._remove_object, key)
+
+    def _remove_object(self, key: str) -> None:
+        self._client.remove_object(self._bucket, key)

--- a/backend/app/workers/registry.py
+++ b/backend/app/workers/registry.py
@@ -7,4 +7,5 @@ tasks are implemented (ingestion, deadline monitor, etc.).
 TASK_REGISTRY: dict[str, str] = {
     "ping": "opencase.ping",
     "sleep": "opencase.sleep",
+    "ingest_document": "opencase.ingest_document",
 }

--- a/backend/app/workers/tasks/ingest_document.py
+++ b/backend/app/workers/tasks/ingest_document.py
@@ -1,0 +1,28 @@
+"""Stub Celery task for document ingestion.
+
+Future: downloads from S3, runs Tika text extraction, chunks, embeds
+via Ollama, and stores vectors in Qdrant.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from celery import shared_task  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(name="opencase.ingest_document")  # type: ignore[untyped-decorator]
+def ingest_document(document_id: str, s3_key: str) -> dict[str, str]:
+    """Ingest a document — stub implementation.
+
+    Args:
+        document_id: UUID string of the document record.
+        s3_key: S3 object key where the original file is stored.
+
+    Returns:
+        Status dict with ``{"status": "stub", "document_id": ...}``.
+    """
+    logger.info("ingest_document stub: %s at %s", document_id, s3_key)
+    return {"status": "stub", "document_id": document_id}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -105,6 +105,9 @@ class FakeSession:
     async def delete(self, obj: object) -> None:
         self._deleted.append(obj)
 
+    async def flush(self) -> None:
+        pass
+
     async def commit(self) -> None:
         self.committed = True
 
@@ -112,7 +115,11 @@ class FakeSession:
         pass
 
     async def refresh(self, obj: object) -> None:
-        pass
+        # Simulate server-default timestamps that PostgreSQL would populate
+        now = datetime.now(UTC)
+        for attr in ("created_at", "updated_at"):
+            if hasattr(obj, attr) and getattr(obj, attr) is None:
+                setattr(obj, attr, now)
 
 
 @asynccontextmanager

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -5,8 +5,15 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from shared.models.enums import MatterStatus, Role, TaskState
+from shared.models.enums import (
+    Classification,
+    DocumentSource,
+    MatterStatus,
+    Role,
+    TaskState,
+)
 
+from app.db.models.document import Document
 from app.db.models.firm import Firm
 from app.db.models.matter import Matter
 from app.db.models.matter_access import MatterAccess
@@ -73,6 +80,27 @@ def make_task_submission(**kwargs: object) -> TaskSubmission:
     }
     defaults.update(kwargs)
     return TaskSubmission(**defaults)
+
+
+def make_document(**kwargs: object) -> Document:
+    defaults: dict[str, object] = {
+        "id": uuid.uuid4(),
+        "firm_id": uuid.uuid4(),
+        "matter_id": uuid.uuid4(),
+        "filename": "test.pdf",
+        "file_hash": "a" * 64,
+        "content_type": "application/pdf",
+        "size_bytes": 1024,
+        "source": DocumentSource.defense,
+        "classification": Classification.unclassified,
+        "bates_number": None,
+        "legal_hold": False,
+        "uploaded_by": uuid.uuid4(),
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+    defaults.update(kwargs)
+    return Document(**defaults)
 
 
 def make_matter_access(**kwargs: object) -> MatterAccess:

--- a/backend/tests/test_document_prompt_endpoints.py
+++ b/backend/tests/test_document_prompt_endpoints.py
@@ -1,25 +1,61 @@
-"""Unit tests for document and prompt stub API endpoints.
+"""Unit tests for document and prompt API endpoints.
 
 Uses AsyncClient + in-memory overrides via shared FakeSession / api_client
-from conftest.py.
+from conftest.py.  Document tests use multipart form uploads with a mocked
+S3StorageService.
 """
 
 from __future__ import annotations
 
 import uuid
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from shared.models.enums import Role
 
+from app.storage import get_storage_service
 from tests.conftest import FakeSession, api_client, auth_header
-from tests.factories import make_user
+from tests.factories import make_document, make_user
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 _FIRM_ID = uuid.uuid4()
-_VALID_HASH = "a" * 64  # 64-char hex string (SHA-256)
+_MATTER_ID = uuid.uuid4()
+
+_FILE_CONTENT = b"hello world test document content"
+_FILE_NAME = "evidence.pdf"
+_FILE_CT = "application/pdf"
+
+
+def _mock_storage() -> MagicMock:
+    """Return a mock S3StorageService that records upload calls."""
+    mock = MagicMock()
+    mock.upload_document = AsyncMock(return_value="fake/key/original.pdf")
+    mock.download_document = AsyncMock(return_value=(_FILE_CONTENT, _FILE_CT))
+    mock.delete_document = AsyncMock()
+    return mock
+
+
+def _upload_kwargs(
+    matter_id: uuid.UUID | None = None,
+    source: str = "defense",
+    classification: str = "unclassified",
+    bates_number: str | None = None,
+) -> dict:
+    """Build multipart form data + files for a document upload."""
+    data: dict[str, str] = {
+        "matter_id": str(matter_id or _MATTER_ID),
+        "source": source,
+        "classification": classification,
+    }
+    if bates_number is not None:
+        data["bates_number"] = bates_number
+    return {
+        "files": {"file": (_FILE_NAME, _FILE_CONTENT, _FILE_CT)},
+        "data": data,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -29,60 +65,78 @@ _VALID_HASH = "a" * 64  # 64-char hex string (SHA-256)
 
 class TestCreateDocument:
     @pytest.mark.asyncio
-    async def test_stub_returns_201(self) -> None:
+    async def test_upload_returns_201(self) -> None:
         user = make_user(firm_id=_FIRM_ID, role=Role.admin)
         fake = FakeSession()
-        async with api_client(user, fake) as ac:
-            resp = await ac.post(
-                "/documents/",
-                json={
-                    "matter_id": str(uuid.uuid4()),
-                    "filename": "evidence.pdf",
-                    "content_type": "application/pdf",
-                    "size_bytes": 1024,
-                    "file_hash": _VALID_HASH,
-                    "source": "government_production",
-                    "classification": "brady",
-                },
-                headers=auth_header(user),
-            )
+        mock_storage = _mock_storage()
+
+        from app.main import app
+
+        app.dependency_overrides[get_storage_service] = lambda: mock_storage
+        try:
+            async with api_client(user, fake) as ac:
+                kw = _upload_kwargs(
+                    source="government_production",
+                    classification="brady",
+                )
+                resp = await ac.post(
+                    "/documents/",
+                    headers=auth_header(user),
+                    **kw,
+                )
+        finally:
+            app.dependency_overrides.pop(get_storage_service, None)
+
         assert resp.status_code == 201
         data = resp.json()
-        assert data["filename"] == "evidence.pdf"
+        assert data["filename"] == _FILE_NAME
         assert data["source"] == "government_production"
         assert data["classification"] == "brady"
-        assert data["file_hash"] == _VALID_HASH
+        assert len(data["file_hash"]) == 64
         assert data["firm_id"] == str(user.firm_id)
+        assert data["size_bytes"] == len(_FILE_CONTENT)
+        mock_storage.upload_document.assert_called_once()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "field,value",
-        [
-            ("filename", ""),
-            ("content_type", ""),
-            ("size_bytes", -1),
-            ("file_hash", "tooshort"),
-        ],
-    )
-    async def test_validation_rejects_bad_input(
-        self, field: str, value: object
-    ) -> None:
+    async def test_upload_missing_file_returns_422(self) -> None:
         user = make_user(firm_id=_FIRM_ID, role=Role.admin)
         fake = FakeSession()
-        payload = {
-            "matter_id": str(uuid.uuid4()),
-            "filename": "evidence.pdf",
-            "content_type": "application/pdf",
-            "size_bytes": 1024,
-            "file_hash": _VALID_HASH,
-        }
-        payload[field] = value
-        async with api_client(user, fake) as ac:
-            resp = await ac.post(
-                "/documents/",
-                json=payload,
-                headers=auth_header(user),
-            )
+        mock_storage = _mock_storage()
+
+        from app.main import app
+
+        app.dependency_overrides[get_storage_service] = lambda: mock_storage
+        try:
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    "/documents/",
+                    data={"matter_id": str(_MATTER_ID)},
+                    headers=auth_header(user),
+                )
+        finally:
+            app.dependency_overrides.pop(get_storage_service, None)
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_upload_missing_matter_id_returns_422(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        mock_storage = _mock_storage()
+
+        from app.main import app
+
+        app.dependency_overrides[get_storage_service] = lambda: mock_storage
+        try:
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    "/documents/",
+                    files={"file": (_FILE_NAME, _FILE_CONTENT, _FILE_CT)},
+                    headers=auth_header(user),
+                )
+        finally:
+            app.dependency_overrides.pop(get_storage_service, None)
+
         assert resp.status_code == 422
 
 
@@ -93,13 +147,26 @@ class TestCreateDocument:
 
 class TestListDocuments:
     @pytest.mark.asyncio
-    async def test_stub_returns_empty_list(self) -> None:
+    async def test_returns_empty_list_when_no_documents(self) -> None:
         user = make_user(firm_id=_FIRM_ID, role=Role.admin)
         fake = FakeSession()
         async with api_client(user, fake) as ac:
             resp = await ac.get("/documents/", headers=auth_header(user))
         assert resp.status_code == 200
         assert resp.json() == []
+
+    @pytest.mark.asyncio
+    async def test_returns_documents_for_admin(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(firm_id=_FIRM_ID, matter_id=_MATTER_ID, uploaded_by=user.id)
+        fake = FakeSession()
+        fake.add_results_list([doc])
+        async with api_client(user, fake) as ac:
+            resp = await ac.get("/documents/", headers=auth_header(user))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == str(doc.id)
 
 
 # ---------------------------------------------------------------------------
@@ -109,11 +176,75 @@ class TestListDocuments:
 
 class TestGetDocument:
     @pytest.mark.asyncio
-    async def test_stub_returns_404(self) -> None:
+    async def test_returns_404_when_not_found(self) -> None:
         user = make_user(firm_id=_FIRM_ID, role=Role.admin)
         fake = FakeSession()
         async with api_client(user, fake) as ac:
             resp = await ac.get(f"/documents/{uuid.uuid4()}", headers=auth_header(user))
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_returns_document_metadata(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(firm_id=_FIRM_ID, matter_id=_MATTER_ID, uploaded_by=user.id)
+        fake = FakeSession()
+        fake.add_result(doc)
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(f"/documents/{doc.id}", headers=auth_header(user))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == str(doc.id)
+        assert data["filename"] == doc.filename
+        assert data["file_hash"] == doc.file_hash
+
+
+# ---------------------------------------------------------------------------
+# GET /documents/{document_id}/download
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadDocument:
+    @pytest.mark.asyncio
+    async def test_returns_file_bytes(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(firm_id=_FIRM_ID, matter_id=_MATTER_ID, uploaded_by=user.id)
+        fake = FakeSession()
+        fake.add_result(doc)
+        mock_storage = _mock_storage()
+
+        from app.main import app
+
+        app.dependency_overrides[get_storage_service] = lambda: mock_storage
+        try:
+            async with api_client(user, fake) as ac:
+                resp = await ac.get(
+                    f"/documents/{doc.id}/download", headers=auth_header(user)
+                )
+        finally:
+            app.dependency_overrides.pop(get_storage_service, None)
+
+        assert resp.status_code == 200
+        assert resp.content == _FILE_CONTENT
+        assert "attachment" in resp.headers.get("content-disposition", "")
+        mock_storage.download_document.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_not_found(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        mock_storage = _mock_storage()
+
+        from app.main import app
+
+        app.dependency_overrides[get_storage_service] = lambda: mock_storage
+        try:
+            async with api_client(user, fake) as ac:
+                resp = await ac.get(
+                    f"/documents/{uuid.uuid4()}/download", headers=auth_header(user)
+                )
+        finally:
+            app.dependency_overrides.pop(get_storage_service, None)
+
         assert resp.status_code == 404
 
 

--- a/backend/tests/test_document_upload_integration.py
+++ b/backend/tests/test_document_upload_integration.py
@@ -1,0 +1,220 @@
+"""Integration tests for the document upload, list, get, and download flow.
+
+These tests run against the full Docker Compose stack (MinIO + PostgreSQL +
+FastAPI) and require ``pytest -m integration``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import httpx
+import pytest
+from minio import Minio  # type: ignore[import-untyped]
+
+
+def _login(base_url: str, email: str, password: str) -> dict[str, str]:
+    """Login and return Authorization header dict."""
+    resp = httpx.post(
+        f"{base_url}/auth/login",
+        json={"email": email, "password": password},
+        timeout=10,
+    )
+    assert resp.status_code == 200, f"Login failed: {resp.text}"
+    data = resp.json()
+    token = data.get("access_token") or data.get("mfa_token")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _login_user(base_url: str, seed: dict[str, Any], user_key: str) -> dict[str, str]:
+    """Login a seeded user by key (e.g. 'user_a')."""
+    u = seed[user_key]
+    return _login(base_url, u["email"], u["password"])
+
+
+def _upload_document(
+    base_url: str,
+    headers: dict[str, str],
+    matter_id: str,
+    file_content: bytes = b"integration test file content",
+    filename: str = "test_doc.pdf",
+    content_type: str = "application/pdf",
+) -> httpx.Response:
+    """Upload a document via multipart form."""
+    return httpx.post(
+        f"{base_url}/documents/",
+        headers=headers,
+        files={"file": (filename, file_content, content_type)},
+        data={
+            "matter_id": matter_id,
+            "source": "defense",
+            "classification": "unclassified",
+        },
+        timeout=30,
+    )
+
+
+@pytest.mark.integration
+class TestDocumentUploadRoundtrip:
+    def test_upload_and_download(self, fastapi_service, seed_demo) -> None:
+        """Upload, list, get metadata, download."""
+        base_url = fastapi_service
+        headers = _login_user(base_url, seed_demo, "user_a")
+        matter_id = str(seed_demo["matter_a"]["id"])
+        file_content = b"roundtrip integration test content"
+        expected_hash = hashlib.sha256(file_content).hexdigest()
+
+        # Upload
+        resp = _upload_document(
+            base_url,
+            headers,
+            matter_id,
+            file_content=file_content,
+        )
+        assert resp.status_code == 201, resp.text
+        doc = resp.json()
+        doc_id = doc["id"]
+        assert doc["filename"] == "test_doc.pdf"
+        assert doc["size_bytes"] == len(file_content)
+        assert doc["file_hash"] == expected_hash
+        assert doc["firm_id"] == str(seed_demo["firm_id"])
+
+        # List
+        resp = httpx.get(
+            f"{base_url}/documents/",
+            params={"matter_id": matter_id},
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        docs = resp.json()
+        assert any(d["id"] == doc_id for d in docs)
+
+        # Get metadata
+        resp = httpx.get(
+            f"{base_url}/documents/{doc_id}",
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["file_hash"] == expected_hash
+
+        # Download
+        resp = httpx.get(
+            f"{base_url}/documents/{doc_id}/download",
+            headers=headers,
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        assert resp.content == file_content
+
+    def test_dedup_rejects_same_hash(self, fastapi_service, seed_demo) -> None:
+        """Upload same file twice — second returns 409."""
+        base_url = fastapi_service
+        headers = _login_user(base_url, seed_demo, "user_a")
+        matter_id = str(seed_demo["matter_a"]["id"])
+        content = b"dedup test content unique bytes"
+
+        # First upload — success
+        resp = _upload_document(
+            base_url,
+            headers,
+            matter_id,
+            file_content=content,
+            filename="first.pdf",
+        )
+        assert resp.status_code == 201
+
+        # Second upload (same content) — duplicate
+        resp = _upload_document(
+            base_url,
+            headers,
+            matter_id,
+            file_content=content,
+            filename="second.pdf",
+        )
+        assert resp.status_code == 409
+
+    def test_same_file_different_matter_accepted(
+        self, fastapi_service, seed_demo
+    ) -> None:
+        """Same file in two matters succeeds."""
+        base_url = fastapi_service
+        headers = _login_user(base_url, seed_demo, "user_a")
+        content = b"cross-matter dedup test"
+
+        # Upload to matter A
+        resp = _upload_document(
+            base_url,
+            headers,
+            str(seed_demo["matter_a"]["id"]),
+            file_content=content,
+        )
+        assert resp.status_code == 201
+
+        # Upload to matter B (user A has access to both)
+        resp = _upload_document(
+            base_url,
+            headers,
+            str(seed_demo["matter_b"]["id"]),
+            file_content=content,
+        )
+        assert resp.status_code == 201
+
+
+@pytest.mark.integration
+class TestDocumentAccessControl:
+    def test_upload_no_matter_access_returns_404(
+        self, fastapi_service, seed_demo
+    ) -> None:
+        """User B (no access to matter A) gets 404."""
+        base_url = fastapi_service
+        headers = _login_user(base_url, seed_demo, "user_b")
+        matter_id = str(seed_demo["matter_a"]["id"])
+
+        resp = _upload_document(base_url, headers, matter_id)
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestDocumentS3Metadata:
+    def test_s3_metadata_stored(
+        self, fastapi_service, seed_demo, minio_service
+    ) -> None:
+        """Verify S3 object metadata fields."""
+        base_url = fastapi_service
+        headers = _login_user(base_url, seed_demo, "user_a")
+        matter_id = str(seed_demo["matter_a"]["id"])
+        file_content = b"metadata test unique content"
+
+        resp = _upload_document(
+            base_url,
+            headers,
+            matter_id,
+            file_content=file_content,
+        )
+        assert resp.status_code == 201
+        doc = resp.json()
+
+        # Read S3 metadata directly via minio client
+        host, port = minio_service
+        mc = Minio(
+            f"{host}:{port}",
+            access_key="opencase",
+            secret_key="changeme",  # noqa: S106
+            secure=False,
+        )
+
+        firm_id = doc["firm_id"]
+        doc_id = doc["id"]
+        key = f"{firm_id}/{matter_id}/{doc_id}/original.pdf"
+
+        stat = mc.stat_object("opencase", key)
+        meta = stat.metadata
+
+        # MinIO lowercases and adds 'x-amz-meta-' prefix
+        assert meta.get("x-amz-meta-document-id") == doc_id
+        assert meta.get("x-amz-meta-matter-id") == matter_id
+        assert meta.get("x-amz-meta-sha256") == doc["file_hash"]
+        assert "x-amz-meta-ingestion-timestamp" in meta

--- a/backend/tests/test_hashing.py
+++ b/backend/tests/test_hashing.py
@@ -1,0 +1,77 @@
+"""Unit tests for app.storage.hashing — chunked SHA-256 with size enforcement."""
+
+from __future__ import annotations
+
+import hashlib
+from io import BytesIO
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.storage.hashing import FileTooLargeError, read_and_hash
+
+
+def _make_upload_file(content: bytes) -> AsyncMock:
+    """Create a mock UploadFile backed by a BytesIO."""
+    buf = BytesIO(content)
+
+    mock = AsyncMock()
+
+    async def _read(size: int = -1) -> bytes:
+        return buf.read(size)
+
+    mock.read = _read
+    return mock
+
+
+class TestReadAndHash:
+    @pytest.mark.asyncio
+    async def test_computes_correct_sha256(self) -> None:
+        content = b"the quick brown fox jumps over the lazy dog"
+        expected = hashlib.sha256(content).hexdigest()
+
+        upload = _make_upload_file(content)
+        data, digest, size = await read_and_hash(upload)
+
+        assert digest == expected
+        assert size == len(content)
+
+    @pytest.mark.asyncio
+    async def test_returns_bytesio_seeked_to_zero(self) -> None:
+        content = b"some file content"
+        upload = _make_upload_file(content)
+
+        data, _digest, _size = await read_and_hash(upload)
+
+        assert data.tell() == 0
+        assert data.read() == content
+
+    @pytest.mark.asyncio
+    async def test_enforces_size_limit(self) -> None:
+        max_bytes = 100
+        content = b"x" * (max_bytes + 1)
+        upload = _make_upload_file(content)
+
+        with pytest.raises(FileTooLargeError):
+            await read_and_hash(upload, max_bytes=max_bytes)
+
+    @pytest.mark.asyncio
+    async def test_allows_exact_size_limit(self) -> None:
+        max_bytes = 100
+        content = b"x" * max_bytes
+        upload = _make_upload_file(content)
+
+        data, digest, size = await read_and_hash(upload, max_bytes=max_bytes)
+        assert size == max_bytes
+
+    @pytest.mark.asyncio
+    async def test_empty_file(self) -> None:
+        content = b""
+        expected = hashlib.sha256(content).hexdigest()
+        upload = _make_upload_file(content)
+
+        data, digest, size = await read_and_hash(upload)
+
+        assert digest == expected
+        assert size == 0
+        assert data.read() == b""

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -12,8 +12,8 @@ from shared.models.enums import Role
 
 from app.core.permissions import (
     PermissionFilter,
-    _fetch_matter_access,
     build_qdrant_filter,
+    fetch_matter_access,
     require_matter_access,
     require_role,
 )
@@ -147,7 +147,7 @@ async def test_firm_id_always_set() -> None:
 async def test_cross_firm_matter_returns_404() -> None:
     """A user with no MatterAccess row for another firm's matter gets 404.
 
-    The firm-scope join in _fetch_matter_access ensures that even if a
+    The firm-scope join in fetch_matter_access ensures that even if a
     MatterAccess row somehow existed across firms, the Matter.firm_id
     check would reject it.
     """
@@ -162,7 +162,7 @@ async def test_cross_firm_matter_returns_404() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _fetch_matter_access tests
+# fetch_matter_access tests
 # ---------------------------------------------------------------------------
 
 
@@ -172,7 +172,7 @@ async def test_fetch_returns_access_row() -> None:
     access = _make_access(user.id)
     db = _mock_db(access)
 
-    result = await _fetch_matter_access(_MATTER_ID, user, db)
+    result = await fetch_matter_access(_MATTER_ID, user, db)
 
     assert result is access
 
@@ -183,7 +183,7 @@ async def test_fetch_raises_404_when_no_row() -> None:
     db = _mock_db(None)
 
     with pytest.raises(HTTPException) as exc_info:
-        await _fetch_matter_access(_MATTER_ID, user, db)
+        await fetch_matter_access(_MATTER_ID, user, db)
 
     assert exc_info.value.status_code == 404
 

--- a/backend/tests/test_storage_service.py
+++ b/backend/tests/test_storage_service.py
@@ -1,0 +1,138 @@
+"""Unit tests for app.storage.s3 — S3StorageService with mocked Minio client."""
+
+from __future__ import annotations
+
+import uuid
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.storage.s3 import S3StorageService
+
+
+@pytest.fixture
+def s3_settings() -> MagicMock:
+    settings = MagicMock()
+    settings.endpoint = "minio:9000"
+    settings.access_key = "testkey"
+    settings.secret_key = "testsecret"  # noqa: S105
+    settings.use_ssl = False
+    settings.region = "us-east-1"
+    settings.bucket = "opencase"
+    return settings
+
+
+@pytest.fixture
+def mock_minio() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def service(s3_settings: MagicMock, mock_minio: MagicMock) -> S3StorageService:
+    with patch("app.storage.s3.Minio", return_value=mock_minio):
+        svc = S3StorageService(s3_settings)
+    return svc
+
+
+class TestObjectKey:
+    def test_key_pattern(self) -> None:
+        firm = uuid.uuid4()
+        matter = uuid.uuid4()
+        doc = uuid.uuid4()
+        key = S3StorageService.object_key(firm, matter, doc, "pdf")
+        assert key == f"{firm}/{matter}/{doc}/original.pdf"
+
+    def test_key_with_different_extension(self) -> None:
+        firm = uuid.uuid4()
+        matter = uuid.uuid4()
+        doc = uuid.uuid4()
+        key = S3StorageService.object_key(firm, matter, doc, "docx")
+        assert key.endswith("/original.docx")
+
+
+class TestUploadDocument:
+    @pytest.mark.asyncio
+    async def test_calls_put_object_with_correct_args(
+        self, service: S3StorageService, mock_minio: MagicMock
+    ) -> None:
+        firm_id = uuid.uuid4()
+        matter_id = uuid.uuid4()
+        doc_id = uuid.uuid4()
+        data = BytesIO(b"file content")
+        file_hash = "a" * 64
+
+        key = await service.upload_document(
+            firm_id=firm_id,
+            matter_id=matter_id,
+            document_id=doc_id,
+            extension="pdf",
+            data=data,
+            size=12,
+            content_type="application/pdf",
+            file_hash=file_hash,
+        )
+
+        expected_key = f"{firm_id}/{matter_id}/{doc_id}/original.pdf"
+        assert key == expected_key
+
+        mock_minio.put_object.assert_called_once()
+        call_args = mock_minio.put_object.call_args
+        assert call_args[0][0] == "opencase"  # bucket
+        assert call_args[0][1] == expected_key  # key
+
+    @pytest.mark.asyncio
+    async def test_metadata_includes_required_fields(
+        self, service: S3StorageService, mock_minio: MagicMock
+    ) -> None:
+        firm_id = uuid.uuid4()
+        matter_id = uuid.uuid4()
+        doc_id = uuid.uuid4()
+        file_hash = "b" * 64
+
+        await service.upload_document(
+            firm_id=firm_id,
+            matter_id=matter_id,
+            document_id=doc_id,
+            extension="pdf",
+            data=BytesIO(b"x"),
+            size=1,
+            content_type="application/pdf",
+            file_hash=file_hash,
+        )
+
+        call_kwargs = mock_minio.put_object.call_args
+        metadata = call_kwargs.kwargs.get("metadata") or call_kwargs[1].get("metadata")
+        assert metadata["document-id"] == str(doc_id)
+        assert metadata["matter-id"] == str(matter_id)
+        assert metadata["sha256"] == file_hash
+        assert "ingestion-timestamp" in metadata
+
+
+class TestDownloadDocument:
+    @pytest.mark.asyncio
+    async def test_returns_bytes_and_content_type(
+        self, service: S3StorageService, mock_minio: MagicMock
+    ) -> None:
+        content = b"downloaded file content"
+        mock_response = MagicMock()
+        mock_response.read.return_value = content
+        mock_response.headers = {"Content-Type": "application/pdf"}
+        mock_minio.get_object.return_value = mock_response
+
+        data, ct = await service.download_document("some/key/original.pdf")
+
+        assert data == content
+        assert ct == "application/pdf"
+        mock_response.close.assert_called_once()
+        mock_response.release_conn.assert_called_once()
+
+
+class TestDeleteDocument:
+    @pytest.mark.asyncio
+    async def test_calls_remove_object(
+        self, service: S3StorageService, mock_minio: MagicMock
+    ) -> None:
+        key = "firm/matter/doc/original.pdf"
+        await service.delete_document(key)
+        mock_minio.remove_object.assert_called_once_with("opencase", key)

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,6 +1,6 @@
 # OpenCase — Entity Relationship Diagram
 
-Covers tables through Feature 2.6. Tables from later features
+Covers tables through Feature 3.2. Tables from later features
 (audit_log, witnesses, disclosure_checklist, etc.) will be added
 as each feature lands.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -44,9 +44,9 @@
 | ID | Feature | Specs | Code | Docs |
 | --- | --- | --- | --- | --- |
 | 3.1 | MinIO container setup + default bucket | Done | Done | Done |
-| 3.2 | API integration (boto3/minio-py, app/storage/) | Pending | Pending | Pending |
+| 3.2 | API integration (boto3/minio-py, app/storage/) | Done | Done | Done |
 | 3.3 | Configuration + env vars (S3Settings) | Done | Done | Done |
-| 3.4 | Observability (S3 operation spans/metrics) | Pending | Pending | Pending |
+| 3.4 | Observability (S3 operation spans/metrics) | Done | Done | Pending |
 
 ## Feature 4 — Document Extraction
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -135,6 +135,8 @@ be invoked by API callers.
 ```python
 TASK_REGISTRY: dict[str, str] = {
     "ping": "opencase.ping",
+    "sleep": "opencase.sleep",
+    "ingest_document": "opencase.ingest_document",
 }
 ```
 
@@ -165,13 +167,27 @@ result = app.send_task("opencase.ping")
 assert result.get(timeout=10) == "pong"
 ```
 
+### `opencase.ingest_document`
+
+Stub task for the document ingestion pipeline. Currently logs the
+request; the full pipeline (Tika extraction, chunking, embedding,
+Qdrant upsert) will be added in Features 4–5.
+
+| Field | Value |
+| --- | --- |
+| Module | `app.workers.tasks.ingest_document` |
+| Name | `opencase.ingest_document` |
+| Arguments | `document_id: str`, `s3_key: str` |
+| Returns | `{"status": "stub", "document_id": ...}` |
+| Purpose | Placeholder for the full ingestion pipeline |
+
 ### Future tasks
 
 Tasks will be added as features are built:
 
 | Task | Feature | Purpose |
 | --- | --- | --- |
-| Document ingestion | 6.3 | SHA-256 dedup, store to MinIO, trigger extraction |
+| Document ingestion (full) | 4.2, 5.2, 5.3 | Tika extraction, chunking, embedding, Qdrant upsert |
 | Cloud ingestion | 6.7 | Poll OneDrive/SharePoint via Graph API |
 | Text extraction | 4.2 | Parse documents via Apache Tika |
 | Chunking + embedding | 5.2, 5.3 | Split text, embed via Ollama, upsert to Qdrant |

--- a/shared/shared/models/__init__.py
+++ b/shared/shared/models/__init__.py
@@ -13,7 +13,6 @@ from shared.models.auth import (
 )
 from shared.models.base import MessageResponse
 from shared.models.document import (
-    CreateDocumentRequest,
     DocumentResponse,
     DocumentSummary,
 )
@@ -54,7 +53,6 @@ from shared.models.user import (
 
 __all__ = [
     "Classification",
-    "CreateDocumentRequest",
     "CreateMatterRequest",
     "CreatePromptRequest",
     "CreateUserRequest",

--- a/shared/shared/models/document.py
+++ b/shared/shared/models/document.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from shared.models.enums import Classification, DocumentSource
 
@@ -34,21 +34,3 @@ class DocumentResponse(DocumentSummary):
     uploaded_by: UUID
     created_at: datetime
     updated_at: datetime
-
-
-# ---------------------------------------------------------------------------
-# Requests
-# ---------------------------------------------------------------------------
-
-
-class CreateDocumentRequest(BaseModel):
-    matter_id: UUID
-    filename: str = Field(min_length=1, max_length=512)
-    content_type: str = Field(min_length=1, max_length=255)
-    size_bytes: int = Field(ge=0)
-    file_hash: str = Field(
-        min_length=64, max_length=64, description="SHA-256 hex digest"
-    )
-    source: DocumentSource = DocumentSource.defense
-    classification: Classification = Classification.unclassified
-    bates_number: str | None = Field(default=None, max_length=100)


### PR DESCRIPTION
## Summary
- **S3StorageService** (`app/storage/s3.py`) — async minio-py wrapper with upload, download, delete and OTel tracing
- **SHA-256 hashing** (`app/storage/hashing.py`) — chunked streaming hash with 100MB size limit
- **Document endpoints** (`app/api/documents.py`) — full CRUD replacing stubs:
  - `POST /documents/` — multipart upload with content-type allowlist, filename sanitization, dedup via DB unique constraint, S3 storage, orphan cleanup on commit failure
  - `GET /documents/` — list with matter-scoped access control
  - `GET /documents/{id}` — metadata retrieval
  - `GET /documents/{id}/download` — RFC 5987 Content-Disposition encoding
- **Ingestion stubs** — `IngestionService` and `opencase.ingest_document` Celery task (placeholders for Tika/Qdrant pipeline)
- **Security fixes** — content-type allowlist (415 on disallowed types), filename sanitization (strip path traversal and special chars), header injection prevention, S3 orphan cleanup
- **Refactor** — renamed `_fetch_matter_access` → `fetch_matter_access` (public API), removed unused `CreateDocumentRequest`
- **Docs** — updated FEATURES.md (3.2 Done), TASKS.md (ingest_document task), ERD.md

## Test plan
- [x] 5 unit tests for SHA-256 hashing (chunked, size limit, empty file)
- [x] 6 unit tests for S3StorageService (upload, download, delete, key pattern, metadata)
- [x] 13 unit tests for document endpoints (upload, list, get, download, validation)
- [x] 18 permission tests pass (renamed function)
- [x] 4 integration tests (upload roundtrip, dedup, cross-matter, access control, S3 metadata)
- [x] All pre-commit hooks pass (ruff, mypy, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)