### PR TITLE
feat: add ExtractionSettings and IngestionSettings config classes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,6 +190,29 @@ OPENCASE_FLOWER_PORT="5555"
 OPENCASE_FLOWER_URL_PREFIX="/flower"
 
 # =============================================================================
+# Extraction Pipeline (OPENCASE_EXTRACTION_ prefix — read by pydantic-settings)
+# =============================================================================
+# Apache Tika server endpoint (Docker service name inside compose network)
+OPENCASE_EXTRACTION_TIKA_URL="http://tika:9998"
+# Enable Tesseract OCR for scanned/image documents
+OPENCASE_EXTRACTION_OCR_ENABLED="true"
+# Tesseract language packs (comma-separated, e.g. "eng,fra,deu")
+OPENCASE_EXTRACTION_OCR_LANGUAGES="eng"
+# HTTP timeout for Tika extraction requests (seconds)
+OPENCASE_EXTRACTION_REQUEST_TIMEOUT="120"
+# Maximum file size sent to Tika for extraction (bytes, default 100 MB)
+OPENCASE_EXTRACTION_MAX_FILE_SIZE_BYTES="104857600"
+
+# =============================================================================
+# Ingestion (OPENCASE_INGESTION_ prefix — read by pydantic-settings)
+# =============================================================================
+# Path to a flat file listing allowed MIME types and file extensions
+# (one entry per line, # comments allowed). When unset, built-in defaults
+# are used (PDF, Word, Excel, images, etc.). See docs/SETTINGS.md for
+# format details and the full default list.
+# OPENCASE_INGESTION_ALLOWED_TYPES_FILE="/etc/opencase/allowed_types.txt"
+
+# =============================================================================
 # Cloud Ingestion — Azure (internet mode only)
 # =============================================================================
 # Required only when DEPLOYMENT_MODE="internet"

--- a/.env.example
+++ b/.env.example
@@ -192,7 +192,8 @@ OPENCASE_FLOWER_URL_PREFIX="/flower"
 # =============================================================================
 # Extraction Pipeline (OPENCASE_EXTRACTION_ prefix — read by pydantic-settings)
 # =============================================================================
-# Apache Tika server endpoint (Docker service name inside compose network)
+# Apache Tika server endpoint (Docker service name inside compose network).
+# For local dev without Docker, change to http://localhost:9998.
 OPENCASE_EXTRACTION_TIKA_URL="http://tika:9998"
 # Enable Tesseract OCR for scanned/image documents
 OPENCASE_EXTRACTION_OCR_ENABLED="true"

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -146,7 +146,11 @@ async def _get_document_with_access(
 async def get_ingestion_config(
     user: User = Depends(get_current_user),  # noqa: B008
 ) -> IngestionConfigResponse:
-    """Return allowed content types and file extensions for ingestion."""
+    """Return allowed content types and file extensions for ingestion.
+
+    Available to all authenticated users (any role). The CLI needs this
+    to filter files during bulk-ingest before uploading.
+    """
     return IngestionConfigResponse(
         allowed_content_types=sorted(settings.ingestion.allowed_content_types),
         allowed_extensions=sorted(settings.ingestion.allowed_extensions),

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -24,6 +24,7 @@ from shared.models.document import (
     DocumentResponse,
     DocumentSummary,
     DuplicateCheckResponse,
+    IngestionConfigResponse,
 )
 from shared.models.enums import Classification, DocumentSource, Role
 from sqlalchemy import select
@@ -52,28 +53,6 @@ router = APIRouter(prefix="/documents", tags=["documents"])
 # Helpers
 # ---------------------------------------------------------------------------
 
-
-_ALLOWED_CONTENT_TYPES = frozenset(
-    {
-        "application/pdf",
-        "application/msword",
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-        "application/rtf",
-        "text/plain",
-        "text/markdown",
-        "text/csv",
-        "text/html",
-        "image/jpeg",
-        "image/png",
-        "image/tiff",
-        "image/gif",
-        "image/bmp",
-        "image/webp",
-        "application/octet-stream",
-    }
-)
 
 _SAFE_FILENAME_RE = re.compile(r"[^\w\s\-.,()]+")
 
@@ -159,6 +138,22 @@ async def _get_document_with_access(
 
 
 # ---------------------------------------------------------------------------
+# GET /documents/ingestion-config
+# ---------------------------------------------------------------------------
+
+
+@router.get("/ingestion-config", response_model=IngestionConfigResponse)
+async def get_ingestion_config(
+    user: User = Depends(get_current_user),  # noqa: B008
+) -> IngestionConfigResponse:
+    """Return allowed content types and file extensions for ingestion."""
+    return IngestionConfigResponse(
+        allowed_content_types=sorted(settings.ingestion.allowed_content_types),
+        allowed_extensions=sorted(settings.ingestion.allowed_extensions),
+    )
+
+
+# ---------------------------------------------------------------------------
 # POST /documents/
 # ---------------------------------------------------------------------------
 
@@ -192,7 +187,7 @@ async def create_document(
 
         # 2. Validate content type
         content_type = file.content_type or "application/octet-stream"
-        if content_type not in _ALLOWED_CONTENT_TYPES:
+        if content_type not in settings.ingestion.allowed_content_types:
             raise HTTPException(
                 status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
                 detail=f"Content type '{content_type}' is not allowed",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from importlib.metadata import version
 from pathlib import Path
 from typing import Any, Literal
@@ -202,6 +203,12 @@ class ExtractionSettings(BaseSettings):
     request_timeout: int = Field(120, gt=0)
     max_file_size_bytes: int = Field(100 * 1024 * 1024, gt=0)  # 100 MB
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def ocr_language_list(self) -> list[str]:
+        """Parse comma-separated language codes into a list."""
+        return [lang.strip() for lang in self.ocr_languages.split(",") if lang.strip()]
+
     model_config = SettingsConfigDict(env_prefix="OPENCASE_EXTRACTION_")
 
 
@@ -209,7 +216,9 @@ class ExtractionSettings(BaseSettings):
 # Ingestion defaults
 # ---------------------------------------------------------------------------
 
-_DEFAULT_CONTENT_TYPES = frozenset(
+_MIME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9!#$&\-^_]+/[a-zA-Z0-9!#$&\-^_.+]+$")
+
+DEFAULT_CONTENT_TYPES = frozenset(
     {
         "application/pdf",
         "application/msword",
@@ -231,7 +240,7 @@ _DEFAULT_CONTENT_TYPES = frozenset(
     }
 )
 
-_DEFAULT_EXTENSIONS = frozenset(
+DEFAULT_EXTENSIONS = frozenset(
     {
         ".pdf",
         ".doc",
@@ -256,6 +265,48 @@ _DEFAULT_EXTENSIONS = frozenset(
 )
 
 
+def _parse_allowed_types_file(
+    path: Path,
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Parse a flat file into (mime_types, extensions).
+
+    Raises ``ValueError`` on missing file, empty result, or invalid entries.
+    """
+    if not path.is_file():
+        msg = f"allowed_types_file not found: {path}"
+        raise ValueError(msg)
+    entries = [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    mime_types: list[str] = []
+    extensions: list[str] = []
+    for entry in entries:
+        if "/" in entry:
+            if not _MIME_RE.match(entry):
+                logger.warning(
+                    "Ignoring invalid MIME type in %s: %r",
+                    path,
+                    entry,
+                )
+                continue
+            mime_types.append(entry)
+        elif entry.startswith(".") and len(entry) > 1:
+            extensions.append(entry)
+        else:
+            logger.warning(
+                "Ignoring unrecognized entry in %s: %r"
+                " (expected MIME type with '/' or extension with '.')",
+                path,
+                entry,
+            )
+    if not mime_types and not extensions:
+        msg = f"allowed_types_file {path} contains no valid MIME types or extensions"
+        raise ValueError(msg)
+    return frozenset(mime_types), frozenset(extensions)
+
+
 class IngestionSettings(BaseSettings):
     """Ingestion pipeline sub-config (OPENCASE_INGESTION_ prefix).
 
@@ -263,42 +314,28 @@ class IngestionSettings(BaseSettings):
     When ``allowed_types_file`` is set, MIME types and file extensions are
     loaded from the flat file (one entry per line, ``#`` comments allowed).
     Otherwise built-in defaults are used.
+
+    All authenticated users can read this config via
+    ``GET /documents/ingestion-config`` — the CLI needs it to filter
+    files during bulk-ingest before uploading.
     """
 
     allowed_types_file: Path | None = None
-    allowed_content_types: frozenset[str] = _DEFAULT_CONTENT_TYPES
-    allowed_extensions: frozenset[str] = _DEFAULT_EXTENSIONS
+    allowed_content_types: frozenset[str] = DEFAULT_CONTENT_TYPES
+    allowed_extensions: frozenset[str] = DEFAULT_EXTENSIONS
 
-    @model_validator(mode="after")
-    def _load_allowed_types(self) -> "IngestionSettings":
-        if self.allowed_types_file is None:
-            return self
-        path = Path(self.allowed_types_file)
-        if not path.is_file():
-            msg = f"allowed_types_file not found: {path}"
-            raise ValueError(msg)
-        entries = [
-            line.strip()
-            for line in path.read_text(encoding="utf-8").splitlines()
-            if line.strip() and not line.strip().startswith("#")
-        ]
-        mime_types: list[str] = []
-        extensions: list[str] = []
-        for entry in entries:
-            if "/" in entry:
-                mime_types.append(entry)
-            elif entry.startswith("."):
-                extensions.append(entry)
-            else:
-                logger.warning(
-                    "Ignoring unrecognized entry in %s: %r"
-                    " (expected MIME type with '/' or extension with '.')",
-                    path,
-                    entry,
-                )
-        self.allowed_content_types = frozenset(mime_types)
-        self.allowed_extensions = frozenset(extensions)
-        return self
+    @model_validator(mode="before")
+    @classmethod
+    def _load_allowed_types(cls, values: dict[str, Any]) -> dict[str, Any]:
+        path = values.get("allowed_types_file")
+        if path is None:
+            return values
+        if not isinstance(path, Path):
+            path = Path(path)
+        mime_types, extensions = _parse_allowed_types_file(path)
+        values["allowed_content_types"] = mime_types
+        values["allowed_extensions"] = extensions
+        return values
 
     model_config = SettingsConfigDict(env_prefix="OPENCASE_INGESTION_")
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,6 @@
+import logging
 from importlib.metadata import version
+from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import quote, urlparse
 
@@ -9,6 +11,8 @@ from pydantic_settings import (
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class OtelSettings(BaseSettings):
@@ -185,6 +189,120 @@ class S3Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="OPENCASE_S3_")
 
 
+class ExtractionSettings(BaseSettings):
+    """Document extraction sub-config (OPENCASE_EXTRACTION_ prefix).
+
+    Configures Apache Tika text extraction and Tesseract OCR for the
+    ingestion pipeline.
+    """
+
+    tika_url: str = "http://tika:9998"
+    ocr_enabled: bool = True
+    ocr_languages: str = "eng"
+    request_timeout: int = Field(120, gt=0)
+    max_file_size_bytes: int = Field(100 * 1024 * 1024, gt=0)  # 100 MB
+
+    model_config = SettingsConfigDict(env_prefix="OPENCASE_EXTRACTION_")
+
+
+# ---------------------------------------------------------------------------
+# Ingestion defaults
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CONTENT_TYPES = frozenset(
+    {
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/rtf",
+        "text/plain",
+        "text/markdown",
+        "text/csv",
+        "text/html",
+        "image/jpeg",
+        "image/png",
+        "image/tiff",
+        "image/gif",
+        "image/bmp",
+        "image/webp",
+        "application/octet-stream",
+    }
+)
+
+_DEFAULT_EXTENSIONS = frozenset(
+    {
+        ".pdf",
+        ".doc",
+        ".docx",
+        ".xlsx",
+        ".pptx",
+        ".rtf",
+        ".txt",
+        ".md",
+        ".csv",
+        ".html",
+        ".htm",
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".tiff",
+        ".tif",
+        ".gif",
+        ".bmp",
+        ".webp",
+    }
+)
+
+
+class IngestionSettings(BaseSettings):
+    """Ingestion pipeline sub-config (OPENCASE_INGESTION_ prefix).
+
+    Controls which document types are accepted for upload and bulk-ingest.
+    When ``allowed_types_file`` is set, MIME types and file extensions are
+    loaded from the flat file (one entry per line, ``#`` comments allowed).
+    Otherwise built-in defaults are used.
+    """
+
+    allowed_types_file: Path | None = None
+    allowed_content_types: frozenset[str] = _DEFAULT_CONTENT_TYPES
+    allowed_extensions: frozenset[str] = _DEFAULT_EXTENSIONS
+
+    @model_validator(mode="after")
+    def _load_allowed_types(self) -> "IngestionSettings":
+        if self.allowed_types_file is None:
+            return self
+        path = Path(self.allowed_types_file)
+        if not path.is_file():
+            msg = f"allowed_types_file not found: {path}"
+            raise ValueError(msg)
+        entries = [
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        mime_types: list[str] = []
+        extensions: list[str] = []
+        for entry in entries:
+            if "/" in entry:
+                mime_types.append(entry)
+            elif entry.startswith("."):
+                extensions.append(entry)
+            else:
+                logger.warning(
+                    "Ignoring unrecognized entry in %s: %r"
+                    " (expected MIME type with '/' or extension with '.')",
+                    path,
+                    entry,
+                )
+        self.allowed_content_types = frozenset(mime_types)
+        self.allowed_extensions = frozenset(extensions)
+        return self
+
+    model_config = SettingsConfigDict(env_prefix="OPENCASE_INGESTION_")
+
+
 # ---------------------------------------------------------------------------
 # Secret redaction
 # ---------------------------------------------------------------------------
@@ -259,6 +377,8 @@ class Settings(BaseSettings):
     # S3Settings has required fields (access_key, secret_key) that are
     # satisfied by env vars at startup, same pattern as auth/db.
     s3: S3Settings = Field(default_factory=S3Settings)  # type: ignore[arg-type]
+    extraction: ExtractionSettings = Field(default_factory=ExtractionSettings)  # type: ignore[arg-type]
+    ingestion: IngestionSettings = Field(default_factory=IngestionSettings)
 
     @model_validator(mode="after")
     def _derive_celery_broker_url(self) -> "Settings":

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -14,8 +14,8 @@ from dotenv import dotenv_values
 from pydantic import ValidationError
 
 from app.core.config import (
-    _DEFAULT_CONTENT_TYPES,
-    _DEFAULT_EXTENSIONS,
+    DEFAULT_CONTENT_TYPES,
+    DEFAULT_EXTENSIONS,
     ApiSettings,
     AuthSettings,
     CelerySettings,
@@ -123,13 +123,14 @@ DEFAULTS = {
         "tika_url": "http://tika:9998",
         "ocr_enabled": True,
         "ocr_languages": "eng",
+        "ocr_language_list": ["eng"],
         "request_timeout": 120,
         "max_file_size_bytes": 100 * 1024 * 1024,
     },
     "ingestion": {
         "allowed_types_file": None,
-        "allowed_content_types": _DEFAULT_CONTENT_TYPES,
-        "allowed_extensions": _DEFAULT_EXTENSIONS,
+        "allowed_content_types": DEFAULT_CONTENT_TYPES,
+        "allowed_extensions": DEFAULT_EXTENSIONS,
     },
 }
 
@@ -493,6 +494,7 @@ def test_extraction_defaults():
     assert cfg.tika_url == "http://tika:9998"
     assert cfg.ocr_enabled is True
     assert cfg.ocr_languages == "eng"
+    assert cfg.ocr_language_list == ["eng"]
     assert cfg.request_timeout == 120
     assert cfg.max_file_size_bytes == 100 * 1024 * 1024
 
@@ -510,6 +512,13 @@ def test_extraction_prefix_isolation(monkeypatch):
     assert cfg.tika_url != "wrong"
 
 
+def test_extraction_ocr_languages_comma_separated(monkeypatch):
+    monkeypatch.setenv("OPENCASE_EXTRACTION_OCR_LANGUAGES", "eng,fra,deu")
+    cfg = ExtractionSettings()
+    assert cfg.ocr_languages == "eng,fra,deu"
+    assert cfg.ocr_language_list == ["eng", "fra", "deu"]
+
+
 # ---------------------------------------------------------------------------
 # IngestionSettings — tested directly
 # ---------------------------------------------------------------------------
@@ -518,8 +527,8 @@ def test_extraction_prefix_isolation(monkeypatch):
 def test_ingestion_defaults():
     cfg = IngestionSettings()
     assert cfg.allowed_types_file is None
-    assert cfg.allowed_content_types == _DEFAULT_CONTENT_TYPES
-    assert cfg.allowed_extensions == _DEFAULT_EXTENSIONS
+    assert cfg.allowed_content_types == DEFAULT_CONTENT_TYPES
+    assert cfg.allowed_extensions == DEFAULT_EXTENSIONS
 
 
 def test_ingestion_custom_types_file(tmp_path):
@@ -536,6 +545,13 @@ def test_ingestion_custom_types_file(tmp_path):
 def test_ingestion_missing_file_raises(tmp_path):
     with pytest.raises(ValidationError):
         IngestionSettings(allowed_types_file=tmp_path / "nonexistent.txt")
+
+
+def test_ingestion_empty_file_raises(tmp_path):
+    f = tmp_path / "empty.txt"
+    f.write_text("# only comments\n\n", encoding="utf-8")
+    with pytest.raises(ValidationError, match="no valid"):
+        IngestionSettings(allowed_types_file=f)
 
 
 def test_ingestion_prefix_isolation(monkeypatch):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -14,11 +14,15 @@ from dotenv import dotenv_values
 from pydantic import ValidationError
 
 from app.core.config import (
+    _DEFAULT_CONTENT_TYPES,
+    _DEFAULT_EXTENSIONS,
     ApiSettings,
     AuthSettings,
     CelerySettings,
     DbSettings,
+    ExtractionSettings,
     FlowerSettings,
+    IngestionSettings,
     RedisSettings,
     S3Settings,
     Settings,
@@ -114,6 +118,18 @@ DEFAULTS = {
         "max_upload_bytes": 100 * 1024 * 1024,
         "spool_threshold_bytes": 10 * 1024 * 1024,
         "url": f"http://{_ENV_TEST['OPENCASE_S3_ENDPOINT']}",
+    },
+    "extraction": {
+        "tika_url": "http://tika:9998",
+        "ocr_enabled": True,
+        "ocr_languages": "eng",
+        "request_timeout": 120,
+        "max_file_size_bytes": 100 * 1024 * 1024,
+    },
+    "ingestion": {
+        "allowed_types_file": None,
+        "allowed_content_types": _DEFAULT_CONTENT_TYPES,
+        "allowed_extensions": _DEFAULT_EXTENSIONS,
     },
 }
 
@@ -465,6 +481,68 @@ def test_s3_url_https(monkeypatch):
     monkeypatch.setenv("OPENCASE_S3_USE_SSL", "true")
     cfg = S3Settings()
     assert cfg.url == "https://minio:9000"
+
+
+# ---------------------------------------------------------------------------
+# ExtractionSettings — tested directly
+# ---------------------------------------------------------------------------
+
+
+def test_extraction_defaults():
+    cfg = ExtractionSettings()
+    assert cfg.tika_url == "http://tika:9998"
+    assert cfg.ocr_enabled is True
+    assert cfg.ocr_languages == "eng"
+    assert cfg.request_timeout == 120
+    assert cfg.max_file_size_bytes == 100 * 1024 * 1024
+
+
+def test_extraction_env_override(monkeypatch):
+    monkeypatch.setenv("OPENCASE_EXTRACTION_TIKA_URL", "http://custom:8080")
+    cfg = ExtractionSettings()
+    assert cfg.tika_url == "http://custom:8080"
+
+
+def test_extraction_prefix_isolation(monkeypatch):
+    # OPENCASE_TIKA_URL (wrong prefix) must not override OPENCASE_EXTRACTION_TIKA_URL
+    monkeypatch.setenv("OPENCASE_TIKA_URL", "wrong")
+    cfg = ExtractionSettings()
+    assert cfg.tika_url != "wrong"
+
+
+# ---------------------------------------------------------------------------
+# IngestionSettings — tested directly
+# ---------------------------------------------------------------------------
+
+
+def test_ingestion_defaults():
+    cfg = IngestionSettings()
+    assert cfg.allowed_types_file is None
+    assert cfg.allowed_content_types == _DEFAULT_CONTENT_TYPES
+    assert cfg.allowed_extensions == _DEFAULT_EXTENSIONS
+
+
+def test_ingestion_custom_types_file(tmp_path):
+    f = tmp_path / "types.txt"
+    f.write_text(
+        "# Custom types\napplication/pdf\ntext/plain\n.pdf\n.txt\n",
+        encoding="utf-8",
+    )
+    cfg = IngestionSettings(allowed_types_file=f)
+    assert cfg.allowed_content_types == frozenset({"application/pdf", "text/plain"})
+    assert cfg.allowed_extensions == frozenset({".pdf", ".txt"})
+
+
+def test_ingestion_missing_file_raises(tmp_path):
+    with pytest.raises(ValidationError):
+        IngestionSettings(allowed_types_file=tmp_path / "nonexistent.txt")
+
+
+def test_ingestion_prefix_isolation(monkeypatch):
+    # OPENCASE_ALLOWED_TYPES_FILE (wrong prefix) must not override
+    monkeypatch.setenv("OPENCASE_ALLOWED_TYPES_FILE", "/tmp/wrong.txt")  # noqa: S108
+    cfg = IngestionSettings()
+    assert cfg.allowed_types_file is None
 
 
 # ---------------------------------------------------------------------------

--- a/cli/opencase_cli/commands/documents.py
+++ b/cli/opencase_cli/commands/documents.py
@@ -32,38 +32,16 @@ _DOCUMENT_COLUMNS = [
     "matter_id",
 ]
 
-SUPPORTED_EXTENSIONS = frozenset(
-    {
-        ".pdf",
-        ".doc",
-        ".docx",
-        ".xlsx",
-        ".pptx",
-        ".rtf",
-        ".txt",
-        ".md",
-        ".csv",
-        ".html",
-        ".htm",
-        ".jpg",
-        ".jpeg",
-        ".png",
-        ".tiff",
-        ".tif",
-        ".gif",
-        ".bmp",
-        ".webp",
-    }
-)
 
-
-def _discover_files(directory: Path, *, recursive: bool) -> list[Path]:
-    """Find files with supported extensions in a directory."""
+def _discover_files(
+    directory: Path, *, recursive: bool, extensions: frozenset[str]
+) -> list[Path]:
+    """Find files with extensions allowed by the server's ingestion config."""
     pattern = "**/*" if recursive else "*"
     return sorted(
         p
         for p in directory.glob(pattern)
-        if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS
+        if p.is_file() and p.suffix.lower() in extensions
     )
 
 
@@ -160,32 +138,35 @@ def bulk_ingest(
     json_output: JsonOption = False,
 ) -> None:
     """Bulk-ingest documents from a local directory."""
-    files = _discover_files(directory, recursive=recursive)
-
-    if not files:
-        if json_output:
-            console.print("[]", highlight=False)
-        else:
-            console.print("[dim]No supported files found.[/dim]")
-        return
-
-    if dry_run:
-        if json_output:
-            rows = [{"file": str(f), "status": "pending"} for f in files]
-            console.print(json.dumps(rows, indent=2), highlight=False)
-        else:
-            for f in files:
-                console.print(str(f))
-            console.print(f"\n[bold]{len(files)}[/bold] file(s) found.")
-        return
-
     client = get_client(base_url, timeout, authenticated=True)
-    uploaded = 0
-    skipped = 0
-    failed = 0
-    results: list[dict[str, str]] = []
 
     with handle_errors(), client:
+        config = client.get_ingestion_config()
+        extensions = frozenset(config.allowed_extensions)
+        files = _discover_files(directory, recursive=recursive, extensions=extensions)
+
+        if not files:
+            if json_output:
+                console.print("[]", highlight=False)
+            else:
+                console.print("[dim]No supported files found.[/dim]")
+            return
+
+        if dry_run:
+            if json_output:
+                rows = [{"file": str(f), "status": "pending"} for f in files]
+                console.print(json.dumps(rows, indent=2), highlight=False)
+            else:
+                for f in files:
+                    console.print(str(f))
+                console.print(f"\n[bold]{len(files)}[/bold] file(s) found.")
+            return
+
+        uploaded = 0
+        skipped = 0
+        failed = 0
+        results: list[dict[str, str]] = []
+
         for path in files:
             try:
                 # Pre-hash locally and check for duplicates before uploading
@@ -239,16 +220,18 @@ def bulk_ingest(
                     else:
                         print_error(f"  FAIL  {path.name}: {exc}")
 
-    total = uploaded + skipped + failed
-    if json_output:
-        console.print(json.dumps(results, indent=2), highlight=False, soft_wrap=True)
-    else:
-        console.print(
-            f"\n[bold]{uploaded}[/bold] uploaded, "
-            f"[bold]{skipped}[/bold] skipped (duplicate), "
-            f"[bold]{failed}[/bold] failed "
-            f"out of [bold]{total}[/bold] total."
-        )
+        total = uploaded + skipped + failed
+        if json_output:
+            console.print(
+                json.dumps(results, indent=2), highlight=False, soft_wrap=True
+            )
+        else:
+            console.print(
+                f"\n[bold]{uploaded}[/bold] uploaded, "
+                f"[bold]{skipped}[/bold] skipped (duplicate), "
+                f"[bold]{failed}[/bold] failed "
+                f"out of [bold]{total}[/bold] total."
+            )
 
-    if failed > 0:
-        raise SystemExit(1)
+        if failed > 0:
+            raise SystemExit(1)

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -17,7 +17,11 @@ from shared.models.auth import (
     TokenResponse,
 )
 from shared.models.base import MessageResponse
-from shared.models.document import DocumentResponse, DocumentSummary
+from shared.models.document import (
+    DocumentResponse,
+    DocumentSummary,
+    IngestionConfigResponse,
+)
 from shared.models.enums import TaskState
 from shared.models.firm import FirmResponse
 from shared.models.health import HealthResponse, ReadinessResponse, ServiceChecks
@@ -91,6 +95,34 @@ def mock_client() -> MagicMock:
     mock = MagicMock(spec=OpenCaseClient)
     mock.__enter__ = MagicMock(return_value=mock)
     mock.__exit__ = MagicMock(return_value=False)
+    # Default ingestion config for bulk-ingest tests
+    mock.get_ingestion_config.return_value = IngestionConfigResponse(
+        allowed_content_types=[
+            "application/pdf",
+            "text/plain",
+        ],
+        allowed_extensions=[
+            ".pdf",
+            ".doc",
+            ".docx",
+            ".txt",
+            ".md",
+            ".csv",
+            ".html",
+            ".htm",
+            ".xlsx",
+            ".pptx",
+            ".rtf",
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".tiff",
+            ".tif",
+            ".gif",
+            ".bmp",
+            ".webp",
+        ],
+    )
     return mock
 
 

--- a/cli/tests/test_documents.py
+++ b/cli/tests/test_documents.py
@@ -98,20 +98,21 @@ class TestBulkIngest:
         tmp_path: Path,
     ) -> None:
         _make_files(tmp_path, ["a.pdf", "b.txt", "c.jpg"])
-        result = runner.invoke(
-            app,
-            [
-                "document",
-                "bulk-ingest",
-                str(tmp_path),
-                "--matter-id",
-                _MATTER_ID,
-                "--dry-run",
-            ],
-        )
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                [
+                    "document",
+                    "bulk-ingest",
+                    str(tmp_path),
+                    "--matter-id",
+                    _MATTER_ID,
+                    "--dry-run",
+                ],
+            )
         assert result.exit_code == 0
         assert "3" in result.output
-        # No client calls should have been made
+        # No upload calls should have been made (only get_ingestion_config)
         mock_client.upload_document.assert_not_called()
 
     def test_upload_all_success(
@@ -249,10 +250,11 @@ class TestBulkIngest:
     ) -> None:
         empty = tmp_path / "empty"
         empty.mkdir()
-        result = runner.invoke(
-            app,
-            ["document", "bulk-ingest", str(empty), "--matter-id", _MATTER_ID],
-        )
+        with patch(_PATCH_CLIENT, return_value=mock_client):
+            result = runner.invoke(
+                app,
+                ["document", "bulk-ingest", str(empty), "--matter-id", _MATTER_ID],
+            )
         assert result.exit_code == 0
         assert "no supported files" in result.output.lower()
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -54,7 +54,7 @@
 | --- | --- | --- | --- | --- |
 | 4.1 | Tika container setup | Pending | Pending | Pending |
 | 4.2 | Extraction task definitions (Celery tasks in app/workers/tasks/) | Pending | Pending | Pending |
-| 4.3 | Configuration + env vars (ExtractionSettings) | Pending | Pending | Pending |
+| 4.3 | Configuration + env vars (ExtractionSettings) | **Done** | **Done** | **Done** |
 | 4.4 | Observability (extraction spans/metrics) | Pending | Pending | Pending |
 
 ## Feature 5 — Chunking & Embedding
@@ -85,6 +85,7 @@
 | 6.11 | Duplicate-check API endpoint (`GET /documents/check-duplicate` — lightweight pre-upload hash check) | Pending | **Done** | **Done** |
 | 6.12 | Disk-buffered hashing (SpooledTemporaryFile — small files in RAM, large files spill to disk) | Pending | **Done** | Pending |
 | 6.13 | SDK multipart upload + client-side hashing (`upload_document`, `check_duplicate`, `hash_file`) | Pending | **Done** | Pending |
+| 6.14 | Configuration + env vars (IngestionSettings: `allowed_types_file`, `allowed_content_types`, `allowed_extensions`, ingestion-config API endpoint) | **Done** | **Done** | **Done** |
 
 ## Feature 7 — Audit Logging
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -182,7 +182,7 @@ Document extraction pipeline — Apache Tika text extraction and Tesseract OCR.
 | --- | --- | --- |
 | `OPENCASE_EXTRACTION_TIKA_URL` | `http://tika:9998` | Tika server endpoint |
 | `OPENCASE_EXTRACTION_OCR_ENABLED` | `true` | Enable Tesseract OCR for scanned documents |
-| `OPENCASE_EXTRACTION_OCR_LANGUAGES` | `eng` | Tesseract language packs (comma-separated) |
+| `OPENCASE_EXTRACTION_OCR_LANGUAGES` | `eng` | Tesseract language packs (comma-separated, e.g. `eng,fra,deu`) |
 | `OPENCASE_EXTRACTION_REQUEST_TIMEOUT` | `120` | HTTP timeout for Tika requests (seconds) |
 | `OPENCASE_EXTRACTION_MAX_FILE_SIZE_BYTES` | `104857600` (100 MB) | Maximum file size sent to Tika for extraction |
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -174,6 +174,65 @@ so only one file is in flight at a time.
 
 ---
 
+## ExtractionSettings (`OPENCASE_EXTRACTION_` prefix)
+
+Document extraction pipeline — Apache Tika text extraction and Tesseract OCR.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENCASE_EXTRACTION_TIKA_URL` | `http://tika:9998` | Tika server endpoint |
+| `OPENCASE_EXTRACTION_OCR_ENABLED` | `true` | Enable Tesseract OCR for scanned documents |
+| `OPENCASE_EXTRACTION_OCR_LANGUAGES` | `eng` | Tesseract language packs (comma-separated) |
+| `OPENCASE_EXTRACTION_REQUEST_TIMEOUT` | `120` | HTTP timeout for Tika requests (seconds) |
+| `OPENCASE_EXTRACTION_MAX_FILE_SIZE_BYTES` | `104857600` (100 MB) | Maximum file size sent to Tika for extraction |
+
+---
+
+## IngestionSettings (`OPENCASE_INGESTION_` prefix)
+
+Controls which document types are accepted for upload and CLI bulk-ingest.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENCASE_INGESTION_ALLOWED_TYPES_FILE` | *none* | Path to a flat file listing allowed MIME types and extensions |
+
+When `ALLOWED_TYPES_FILE` is not set, built-in defaults are used. When set, the
+file replaces the defaults entirely.
+
+**File format:** one entry per line. Lines starting with `#` are comments. Blank
+lines are ignored. MIME types (containing `/`) and file extensions (starting with
+`.`) can be mixed freely:
+
+```text
+# Allowed MIME types
+application/pdf
+application/msword
+text/plain
+
+# Allowed file extensions (for CLI bulk-ingest discovery)
+.pdf
+.doc
+.txt
+```
+
+**Default MIME types** (17): `application/pdf`, `application/msword`,
+`application/vnd.openxmlformats-officedocument.wordprocessingml.document`,
+`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`,
+`application/vnd.openxmlformats-officedocument.presentationml.presentation`,
+`application/rtf`, `text/plain`, `text/markdown`, `text/csv`, `text/html`,
+`image/jpeg`, `image/png`, `image/tiff`, `image/gif`, `image/bmp`,
+`image/webp`, `application/octet-stream`.
+
+**Default extensions** (19): `.pdf`, `.doc`, `.docx`, `.xlsx`, `.pptx`, `.rtf`,
+`.txt`, `.md`, `.csv`, `.html`, `.htm`, `.jpg`, `.jpeg`, `.png`, `.tiff`,
+`.tif`, `.gif`, `.bmp`, `.webp`.
+
+The CLI fetches allowed types from the API at bulk-ingest start via
+`GET /documents/ingestion-config`, so the server's configuration is always
+the single source of truth.
+
+---
+
 ## RedisSettings (`OPENCASE_REDIS_` prefix)
 
 Redis connection settings. Individual fields are preferred over a monolithic URL

--- a/sdk/opencase/client.py
+++ b/sdk/opencase/client.py
@@ -18,6 +18,7 @@ from shared.models.document import (
     DocumentResponse,
     DocumentSummary,
     DuplicateCheckResponse,
+    IngestionConfigResponse,
 )
 from shared.models.enums import Classification, DocumentSource, TaskState
 from shared.models.firm import FirmResponse
@@ -270,6 +271,11 @@ class OpenCaseClient:
     def get_document(self, document_id: str) -> DocumentResponse:
         resp = self._request("GET", f"/documents/{document_id}")
         return DocumentResponse.model_validate(resp.json())
+
+    def get_ingestion_config(self) -> IngestionConfigResponse:
+        """Return allowed content types and file extensions for ingestion."""
+        resp = self._request("GET", "/documents/ingestion-config")
+        return IngestionConfigResponse.model_validate(resp.json())
 
     def upload_document(
         self,

--- a/shared/shared/models/document.py
+++ b/shared/shared/models/document.py
@@ -41,3 +41,10 @@ class DuplicateCheckResponse(BaseModel):
 
     exists: bool
     document_id: UUID | None = None
+
+
+class IngestionConfigResponse(BaseModel):
+    """Public-facing ingestion configuration — no server internals."""
+
+    allowed_content_types: list[str]
+    allowed_extensions: list[str]


### PR DESCRIPTION
## Summary

- **ExtractionSettings** (`OPENCASE_EXTRACTION_` prefix) — configures Apache Tika text extraction and Tesseract OCR for the ingestion pipeline: `tika_url`, `ocr_enabled`, `ocr_languages`, `request_timeout`, `max_file_size_bytes`
- **IngestionSettings** (`OPENCASE_INGESTION_` prefix) — configurable document type allowlists via optional flat file (`allowed_types_file`), replacing hardcoded `_ALLOWED_CONTENT_TYPES` in the API and `SUPPORTED_EXTENSIONS` in the CLI
- New `GET /documents/ingestion-config` endpoint with explicit `IngestionConfigResponse` model (no server internals exposed)
- CLI `bulk-ingest` now fetches allowed extensions from the API at runtime — single source of truth

## Test plan

- [x] `pytest backend/tests/test_config.py` — 52 passed (defaults, env override, prefix isolation, custom file, missing file)
- [x] `pytest cli/tests/` — 78 passed, 1 skipped (dry-run, empty dir, extension filtering all work with API-fetched config)
- [x] `pytest sdk/tests/` — 54 passed
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, pytest)

Closes #40, closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)