### PR TITLE
feat: Session context manager + rename Client

### DIFF
--- a/cli/opencase_cli/common.py
+++ b/cli/opencase_cli/common.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 import typer
-from opencase import OpenCaseClient
+from opencase import Client
 
 from opencase_cli.config import load_config
 from opencase_cli.output import print_error
@@ -31,10 +31,10 @@ def get_client(
     timeout: float | None = None,
     *,
     authenticated: bool = False,
-) -> OpenCaseClient:
-    """Create a configured ``OpenCaseClient``, optionally with stored tokens."""
+) -> Client:
+    """Create a configured ``Client``, optionally with stored tokens."""
     config = load_config(base_url=base_url, timeout=timeout)
-    client = OpenCaseClient(base_url=config.base_url, timeout=config.timeout)
+    client = Client(base_url=config.base_url, timeout=config.timeout)
 
     if authenticated:
         tokens = load_tokens()

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -89,10 +89,10 @@ def stored_tokens(tmp_opencase_dir: Path) -> tuple[str, str]:
 
 @pytest.fixture()
 def mock_client() -> MagicMock:
-    """Return a MagicMock that quacks like OpenCaseClient."""
-    from opencase import OpenCaseClient
+    """Return a MagicMock that quacks like Client."""
+    from opencase import Client
 
-    mock = MagicMock(spec=OpenCaseClient)
+    mock = MagicMock(spec=Client)
     mock.__enter__ = MagicMock(return_value=mock)
     mock.__exit__ = MagicMock(return_value=False)
     # Default ingestion config for bulk-ingest tests

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -24,6 +24,8 @@
 | 1.4 | Authentication (JWT, TOTP MFA, login/logout/refresh) | Done | Done | Done |
 | 1.5 | RBAC middleware (role enforcement, `build_qdrant_filter()`) | Done | Done | Done |
 | 1.6 | Python REST client SDK + shared models (sdk/, shared/) | Done | Done | Done |
+| 1.6.1 | SDK: rename `OpenCaseClient` → `Client` (backwards-compat alias kept) | — | **Done** | **Done** |
+| 1.6.2 | SDK: `Session` context manager — auto login/logout, credential scrubbing | — | **Done** | **Done** |
 | 1.7 | CLI (built on SDK) | Done | Done | Done |
 | 1.8 | Core business endpoints (matters, prompt stub, documents stub) | Done | Done | Done |
 

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -21,7 +21,7 @@ import argparse
 import sys
 
 import dotenv
-from opencase import OpenCaseClient
+from opencase import Client
 from opencase.exceptions import OpenCaseError, ValidationError
 
 BASE_URL = "http://127.0.0.1:8000"
@@ -29,7 +29,7 @@ DEMO_PASSWORD = "DemoPassword123!"  # noqa: S105
 
 
 def _create_user(
-    client: OpenCaseClient,
+    client: Client,
     email: str,
     first_name: str,
     last_name: str,
@@ -57,7 +57,7 @@ def _create_user(
         raise
 
 
-def _create_matter(client: OpenCaseClient, name: str) -> str:
+def _create_matter(client: Client, name: str) -> str:
     """Create a matter, return matter_id.  Skip if already exists."""
     import uuid
 
@@ -73,7 +73,7 @@ def _create_matter(client: OpenCaseClient, name: str) -> str:
 
 
 def _grant_access(
-    client: OpenCaseClient,
+    client: Client,
     matter_id: str,
     user_id: str,
     label: str,
@@ -99,7 +99,7 @@ def main(config_file: str) -> None:
         print("ERROR: OPENCASE_ADMIN_EMAIL / OPENCASE_ADMIN_PASSWORD not set in .env")  # noqa: T201
         sys.exit(1)
 
-    with OpenCaseClient(base_url=BASE_URL) as client:
+    with Client(base_url=BASE_URL) as client:
         print(f"Logging in as {admin_email}")  # noqa: T201
         client.login(email=admin_email, password=admin_password)
 

--- a/scripts/submit_task.py
+++ b/scripts/submit_task.py
@@ -1,21 +1,21 @@
 import time
 import dotenv
-from opencase import OpenCaseClient
+from opencase import Client
 
 BASE_URL = "http://127.0.0.1:8000"
 
-def submit_log_running_task(client: OpenCaseClient) -> None:
+def submit_log_running_task(client: Client) -> None:
     print("Submitting long-running task (sleep for 30 seconds)...")
     result = client.submit_task(task_name="sleep", kwargs={"seconds": 30})
     print(f"Submitted: {result.task_id}")
 
-def submit_ping_task(client: OpenCaseClient) -> None:
+def submit_ping_task(client: Client) -> None:
     print("Submitting ping task...")
     result = client.submit_task(task_name="ping")
     print(f"Submitted: {result.task_id}")
     return result
 
-def wait_for_task_result(client: OpenCaseClient, task_id: str) -> None:
+def wait_for_task_result(client: Client, task_id: str) -> None:
     print(f"Waiting for task {task_id} to complete...")
     while True:
         task = client.get_task(task_id)
@@ -31,7 +31,7 @@ def wait_for_task_result(client: OpenCaseClient, task_id: str) -> None:
 
 def main(config_file: str) -> None:
 
-    with OpenCaseClient(base_url=BASE_URL) as client:
+    with Client(base_url=BASE_URL) as client:
 
         admin_email = dotenv.get_key(config_file, "OPENCASE_ADMIN_EMAIL")
         admin_password = dotenv.get_key(config_file, "OPENCASE_ADMIN_PASSWORD")

--- a/scripts/upload_file.py
+++ b/scripts/upload_file.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import dotenv
 import httpx
 from minio import Minio
-from opencase import OpenCaseClient
+from opencase import Client
 
 BASE_URL = "http://127.0.0.1:8000"
 MINIO_ENDPOINT = "localhost:9000"
@@ -34,7 +34,7 @@ MINIO_ENDPOINT = "localhost:9000"
 # ---------------------------------------------------------------------------
 
 
-def pick_matter(client: OpenCaseClient) -> dict:
+def pick_matter(client: Client) -> dict:
     """Return the first matter, or create one if none exist."""
     matters = client.list_matters()
     if matters:
@@ -69,7 +69,7 @@ def prepare_file(file_path: Path | None) -> tuple[Path, str, bool]:
     return file_path, local_hash, cleanup
 
 
-def upload(client: OpenCaseClient, file_path: Path, matter_id: str) -> object:
+def upload(client: Client, file_path: Path, matter_id: str) -> object:
     """Upload the file and print the response."""
     print("\nUploading...")  # noqa: T201
     doc = client.upload_document(file_path=file_path, matter_id=matter_id)
@@ -88,7 +88,7 @@ def verify_hash(doc: object, local_hash: str) -> None:
     print("  Hash match:   OK")  # noqa: T201
 
 
-def verify_database(client: OpenCaseClient, doc_id: str) -> None:
+def verify_database(client: Client, doc_id: str) -> None:
     """Confirm the document record exists via API."""
     print("\nVerifying database (GET /documents/{id})...")  # noqa: T201
     db_doc = client.get_document(doc_id)
@@ -122,7 +122,7 @@ def verify_s3(
     print(f"  S3 timestamp: {meta.get('x-amz-meta-ingestion-timestamp', '???')}")  # noqa: T201
 
 
-def verify_download(client: OpenCaseClient, doc_id: str, local_hash: str) -> None:
+def verify_download(client: Client, doc_id: str, local_hash: str) -> None:
     """Download the file and compare its hash to the original."""
     print("\nVerifying download (GET /documents/{id}/download)...")  # noqa: T201
     resp = httpx.get(
@@ -155,7 +155,7 @@ def main(config_file: str, file_path: Path | None = None) -> None:
         print("ERROR: OPENCASE_ADMIN_EMAIL / OPENCASE_ADMIN_PASSWORD not set")  # noqa: T201
         sys.exit(1)
 
-    with OpenCaseClient(base_url=BASE_URL) as client:
+    with Client(base_url=BASE_URL) as client:
         print(f"Logging in as {admin_email}")  # noqa: T201
         client.login(email=admin_email, password=admin_password)
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -5,9 +5,9 @@ Python REST client for the OpenCase API.
 ## Usage
 
 ```python
-from opencase import OpenCaseClient
+from opencase import Client
 
-client = OpenCaseClient(base_url="http://localhost:8000")
+client = Client(base_url="http://localhost:8000")
 client.login(email="user@firm.com", password="secret")
 
 health = client.health()

--- a/sdk/opencase/__init__.py
+++ b/sdk/opencase/__init__.py
@@ -1,6 +1,6 @@
 """OpenCase Python SDK — REST client for the OpenCase API."""
 
-from opencase.client import OpenCaseClient
+from opencase.client import Client
 from opencase.exceptions import (
     AuthenticationError,
     AuthorizationError,
@@ -9,14 +9,20 @@ from opencase.exceptions import (
     ServerError,
     ValidationError,
 )
+from opencase.session import Session
 
 __version__ = "0.1.0"
+
+# Backwards-compatible alias.
+OpenCaseClient = Client
 
 __all__ = [
     "AuthenticationError",
     "AuthorizationError",
+    "Client",
     "NotFoundError",
     "OpenCaseClient",
+    "Session",
     "OpenCaseError",
     "ServerError",
     "ValidationError",

--- a/sdk/opencase/__init__.py
+++ b/sdk/opencase/__init__.py
@@ -22,8 +22,8 @@ __all__ = [
     "Client",
     "NotFoundError",
     "OpenCaseClient",
-    "Session",
     "OpenCaseError",
     "ServerError",
+    "Session",
     "ValidationError",
 ]

--- a/sdk/opencase/client.py
+++ b/sdk/opencase/client.py
@@ -1,4 +1,4 @@
-"""OpenCaseClient — synchronous REST client for the OpenCase API."""
+"""Synchronous REST client for the OpenCase API."""
 
 from __future__ import annotations
 
@@ -55,7 +55,7 @@ from opencase.exceptions import (
 )
 
 
-class OpenCaseClient:
+class Client:
     """Synchronous Python client for the OpenCase REST API.
 
     Handles JWT lifecycle transparently: auto-refreshes expired access
@@ -63,7 +63,7 @@ class OpenCaseClient:
 
     Usage::
 
-        client = OpenCaseClient(base_url="http://localhost:8000")
+        client = Client(base_url="http://localhost:8000")
         client.login(email="user@firm.com", password="secret")
 
         health = client.health()
@@ -71,7 +71,7 @@ class OpenCaseClient:
 
     Or as a context manager::
 
-        with OpenCaseClient(base_url="http://localhost:8000") as client:
+        with Client(base_url="http://localhost:8000") as client:
             client.login(email="user@firm.com", password="secret")
             ...
     """
@@ -88,7 +88,7 @@ class OpenCaseClient:
 
     # -- context manager -----------------------------------------------------
 
-    def __enter__(self) -> OpenCaseClient:
+    def __enter__(self) -> Client:
         return self
 
     def __exit__(self, *args: object) -> None:

--- a/sdk/opencase/session.py
+++ b/sdk/opencase/session.py
@@ -38,10 +38,12 @@ class Session:
         return self._client
 
     def __enter__(self) -> Client:
-        result = self._client.login(self._email, self._password)  # type: ignore[arg-type]
-        # Scrub credentials — only JWT tokens remain (inside AuthManager).
-        self._email = None
-        self._password = None
+        try:
+            result = self._client.login(self._email, self._password)  # type: ignore[arg-type]
+        finally:
+            # Scrub credentials regardless of success/failure.
+            self._email = None
+            self._password = None
         if isinstance(result, MfaRequiredResponse):
             self._client.close()
             raise AuthenticationError(

--- a/sdk/opencase/session.py
+++ b/sdk/opencase/session.py
@@ -1,0 +1,74 @@
+"""Context manager for automatic login/logout lifecycle."""
+
+from __future__ import annotations
+
+from shared.models.auth import MfaRequiredResponse
+
+from opencase.client import Client
+from opencase.exceptions import AuthenticationError
+
+
+class Session:
+    """Context manager that logs in on entry and logs out on exit.
+
+    Usage::
+
+        with Session("http://localhost:8000", email="u@f.com", password="s") as client:
+            matters = client.list_matters()
+
+    Credentials are scrubbed from the instance immediately after login.
+    If the server requires MFA, ``AuthenticationError`` is raised — use
+    ``Client`` directly for interactive MFA flows.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        email: str,
+        password: str,
+        timeout: float = 30.0,
+    ) -> None:
+        self._client = Client(base_url=base_url, timeout=timeout)
+        self._email: str | None = email
+        self._password: str | None = password
+
+    @property
+    def client(self) -> Client:
+        return self._client
+
+    def __enter__(self) -> Client:
+        result = self._client.login(self._email, self._password)  # type: ignore[arg-type]
+        # Scrub credentials — only JWT tokens remain (inside AuthManager).
+        self._email = None
+        self._password = None
+        if isinstance(result, MfaRequiredResponse):
+            self._client.close()
+            raise AuthenticationError(
+                "MFA required — use Client directly for interactive MFA",
+                status_code=None,
+            )
+        return self._client
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        try:
+            if self._client._auth.is_authenticated:  # noqa: SLF001
+                self._client.logout()
+        finally:
+            self._client.close()
+
+    async def __aenter__(self) -> Client:
+        raise NotImplementedError("Async not supported — the SDK client is synchronous")
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        raise NotImplementedError("Async not supported — the SDK client is synchronous")

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 
 import httpx
 
-from opencase import OpenCaseClient
+from opencase import Client
 
 Handler = Callable[[httpx.Request], httpx.Response]
 
@@ -34,15 +34,15 @@ def mock_http(handler: Handler) -> httpx.Client:
     return httpx.Client(transport=httpx.MockTransport(handler))
 
 
-def build_client(handler: Handler) -> OpenCaseClient:
-    """Create an OpenCaseClient backed by a mock transport."""
-    client = OpenCaseClient(base_url="http://test")
+def build_client(handler: Handler) -> Client:
+    """Create a Client backed by a mock transport."""
+    client = Client(base_url="http://test")
     client._http = mock_http(handler)  # noqa: SLF001
     return client
 
 
-def build_authenticated_client(handler: Handler) -> OpenCaseClient:
-    """Create an OpenCaseClient with pre-stored auth tokens."""
+def build_authenticated_client(handler: Handler) -> Client:
+    """Create a Client with pre-stored auth tokens."""
     client = build_client(handler)
     token = make_jwt(exp=time.time() + 3600)
     client._auth.store_tokens(token, "refresh")  # noqa: SLF001

--- a/sdk/tests/test_client.py
+++ b/sdk/tests/test_client.py
@@ -1,4 +1,4 @@
-"""Unit tests for opencase.client.OpenCaseClient using httpx.MockTransport."""
+"""Unit tests for opencase.client.Client using httpx.MockTransport."""
 
 from __future__ import annotations
 

--- a/sdk/tests/test_session.py
+++ b/sdk/tests/test_session.py
@@ -1,0 +1,188 @@
+"""Unit tests for opencase.session.Session context manager."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import httpx
+import pytest
+
+from opencase import Client, Session
+from opencase.exceptions import AuthenticationError
+from tests.conftest import make_jwt
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_ACCESS = make_jwt(exp=time.time() + 3600)
+_VALID_REFRESH = "refresh-token"
+
+
+def _token_json() -> dict[str, str]:
+    return {
+        "access_token": _VALID_ACCESS,
+        "refresh_token": _VALID_REFRESH,
+        "token_type": "bearer",
+    }
+
+
+def _build_session(handler: httpx.MockTransport | None = None) -> Session:
+    """Create a Session with a mock HTTP transport."""
+    session = Session(
+        "http://test",
+        email="user@firm.com",
+        password="secret",
+    )
+    if handler is not None:
+        session._client._http = httpx.Client(transport=handler)  # noqa: SLF001
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Login lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_enter_calls_login_and_returns_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/auth/login":
+            body = json.loads(request.content)
+            assert body["email"] == "user@firm.com"
+            assert body["password"] == "secret"
+            return httpx.Response(200, json=_token_json())
+        return httpx.Response(404)
+
+    session = _build_session(httpx.MockTransport(handler))
+    client = session.__enter__()
+
+    assert isinstance(client, Client)
+    assert client._auth.is_authenticated  # noqa: SLF001
+
+
+def test_credentials_cleared_after_enter() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_token_json())
+
+    session = _build_session(httpx.MockTransport(handler))
+    session.__enter__()
+
+    assert session._email is None  # noqa: SLF001
+    assert session._password is None  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Logout lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_exit_calls_logout_and_close() -> None:
+    logout_called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal logout_called
+        if request.url.path == "/auth/login":
+            return httpx.Response(200, json=_token_json())
+        if request.url.path == "/auth/logout":
+            logout_called = True
+            return httpx.Response(200, json={"detail": "Logged out"})
+        return httpx.Response(404)
+
+    with _build_session(httpx.MockTransport(handler)) as client:
+        assert client._auth.is_authenticated  # noqa: SLF001
+
+    assert logout_called
+
+
+def test_exit_calls_logout_on_exception() -> None:
+    logout_called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal logout_called
+        if request.url.path == "/auth/login":
+            return httpx.Response(200, json=_token_json())
+        if request.url.path == "/auth/logout":
+            logout_called = True
+            return httpx.Response(200, json={"detail": "Logged out"})
+        return httpx.Response(404)
+
+    session = _build_session(httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError, match="boom"), session:
+        raise RuntimeError("boom")
+
+    assert logout_called
+
+
+def test_exception_propagated() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/auth/login":
+            return httpx.Response(200, json=_token_json())
+        if request.url.path == "/auth/logout":
+            return httpx.Response(200, json={"detail": "Logged out"})
+        return httpx.Response(404)
+
+    session = _build_session(httpx.MockTransport(handler))
+    with pytest.raises(ValueError, match="test error"), session:
+        raise ValueError("test error")
+
+
+# ---------------------------------------------------------------------------
+# MFA required
+# ---------------------------------------------------------------------------
+
+
+def test_mfa_required_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/auth/login":
+            return httpx.Response(
+                200, json={"mfa_required": True, "mfa_token": "mfa-tok"}
+            )
+        return httpx.Response(404)
+
+    session = _build_session(httpx.MockTransport(handler))
+    with pytest.raises(AuthenticationError, match="MFA required"):
+        session.__enter__()
+
+
+# ---------------------------------------------------------------------------
+# Login failure
+# ---------------------------------------------------------------------------
+
+
+def test_login_failure_closes_client() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Invalid credentials"})
+
+    session = _build_session(httpx.MockTransport(handler))
+    with pytest.raises(AuthenticationError), session:
+        pass  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Async not implemented
+# ---------------------------------------------------------------------------
+
+
+def test_async_aenter_not_implemented() -> None:
+    import asyncio
+
+    session = Session("http://test", email="u@f.com", password="p")
+    loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(NotImplementedError, match="Async not supported"):
+            loop.run_until_complete(session.__aenter__())
+    finally:
+        loop.close()
+
+
+def test_async_aexit_not_implemented() -> None:
+    import asyncio
+
+    session = Session("http://test", email="u@f.com", password="p")
+    loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(NotImplementedError, match="Async not supported"):
+            loop.run_until_complete(session.__aexit__(None, None, None))
+    finally:
+        loop.close()

--- a/sdk/tests/test_session.py
+++ b/sdk/tests/test_session.py
@@ -159,6 +159,18 @@ def test_login_failure_closes_client() -> None:
         pass  # pragma: no cover
 
 
+def test_credentials_cleared_on_login_failure() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Invalid credentials"})
+
+    session = _build_session(httpx.MockTransport(handler))
+    with pytest.raises(AuthenticationError):
+        session.__enter__()
+
+    assert session._email is None  # noqa: SLF001
+    assert session._password is None  # noqa: SLF001
+
+
 # ---------------------------------------------------------------------------
 # Async not implemented
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Rename `OpenCaseClient` → `Client` across SDK, CLI, tests, and scripts (backwards-compat alias preserved)
- Add `opencase.Session` context manager for automatic login/logout lifecycle
- Credentials are scrubbed from memory immediately after login
- MFA-required responses raise `AuthenticationError` (use `Client` directly for interactive MFA)
- 9 new unit tests for Session covering login, logout, exception propagation, credential scrubbing, and MFA handling

## Test plan
- [x] SDK tests pass (63 passed)
- [x] CLI tests pass (78 passed, 1 skipped)
- [x] ruff lint + format clean
- [x] mypy passes
- [x] All pre-commit hooks pass

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)