### PR TITLE
docs: add LICENSE and component license inventory

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 OpenCase Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,252 @@
+# Third-Party Licenses
+
+OpenCase is licensed under [Apache 2.0](LICENSE). This
+document inventories the licenses of all third-party
+components used by the project.
+
+All directly-linked Python dependencies use permissive
+licenses (MIT, BSD, Apache 2.0). Components with
+copyleft licenses (AGPL, LGPL) are either isolated
+network services or dynamically-linked C extensions,
+neither of which imposes obligations on the OpenCase
+source code. See the
+[compatibility analysis](#license-compatibility-analysis)
+for details.
+
+**Last updated:** 2026-03-28
+**Source:** `uv.lock`, `backend/pyproject.toml`,
+`infrastructure/docker-compose.yml`
+
+---
+
+## Infrastructure Services
+
+These run as separate Docker containers, accessed over
+TCP/HTTP. OpenCase never links against their source code.
+
+| Component | Image | License | SPDX |
+| --- | --- | --- | --- |
+| PostgreSQL | `postgres:17-alpine` | PostgreSQL License | `PostgreSQL` |
+| Redis | `redis:7-alpine` | BSD-3-Clause / RSALv2+SSPLv1 | See note below |
+| MinIO | `minio/minio:latest` | AGPL-3.0 | `AGPL-3.0-or-later` |
+| MinIO Client | `minio/mc:latest` | AGPL-3.0 | `AGPL-3.0-or-later` |
+| Ollama | `ollama/ollama:latest` | MIT | `MIT` |
+| Qdrant | `qdrant/qdrant:latest` | Apache 2.0 | `Apache-2.0` |
+| Grafana OTEL-LGTM | `grafana/otel-lgtm:latest` | AGPL-3.0 | `AGPL-3.0-or-later` |
+
+**Redis licensing note.** Redis changed its server
+license from BSD-3-Clause to RSALv2 + SSPLv1 starting
+with version 7.4. The `redis:7-alpine` tag is a moving
+target and may resolve to 7.4+. Regardless, Redis is
+used as a standalone network service (Celery broker and
+cache). Neither RSALv2 nor SSPL restricts the license of
+applications that merely connect to Redis over the
+network. The Python `redis` client library remains MIT.
+
+---
+
+## Container Base Images
+
+| Image | License | Usage |
+| --- | --- | --- |
+| `python:3.12-slim` | PSF-2.0 + Debian free software | build / runtime |
+| `node:22-slim` | MIT + Debian free software | build / runtime (planned) |
+| `ghcr.io/astral-sh/uv:latest` | MIT | build (package installer) |
+
+---
+
+## Python Runtime Dependencies
+
+Packages listed in `backend/pyproject.toml` under
+`dependencies`. Versions resolved from `uv.lock`.
+
+| Package | Version | License | SPDX |
+| --- | --- | --- | --- |
+| FastAPI | 0.135.1 | MIT | `MIT` |
+| Uvicorn | 0.42.0 | BSD-3-Clause | `BSD-3-Clause` |
+| Pydantic | 2.12.5 | MIT | `MIT` |
+| pydantic-settings | 2.13.1 | MIT | `MIT` |
+| SQLAlchemy | 2.0.48 | MIT | `MIT` |
+| Alembic | 1.18.4 | MIT | `MIT` |
+| asyncpg | 0.31.0 | Apache 2.0 | `Apache-2.0` |
+| psycopg2-binary | 2.9.11 | LGPL-3.0 | `LGPL-3.0-or-later` |
+| Celery | 5.6.2 | BSD-3-Clause | `BSD-3-Clause` |
+| redis (Python) | 6.4.0 | MIT | `MIT` |
+| LangChain | 1.2.13 | MIT | `MIT` |
+| langchain-community | 0.4.1 | MIT | `MIT` |
+| langchain-ollama | 1.0.1 | MIT | `MIT` |
+| qdrant-client | 1.17.1 | Apache 2.0 | `Apache-2.0` |
+| minio (Python) | 7.2.20 | Apache 2.0 | `Apache-2.0` |
+| python-jose | 3.5.0 | MIT | `MIT` |
+| passlib | 1.7.4 | BSD-3-Clause | `BSD-3-Clause` |
+| PyOTP | 2.9.0 | MIT | `MIT` |
+| cryptography | 46.0.5 | Apache 2.0 / BSD-3-Clause | `Apache-2.0 OR BSD-3-Clause` |
+| python-multipart | 0.0.22 | Apache 2.0 | `Apache-2.0` |
+
+---
+
+## OpenTelemetry Stack
+
+All OpenTelemetry packages are Apache 2.0.
+
+| Package | Version |
+| --- | --- |
+| opentelemetry-api | 1.40.0 |
+| opentelemetry-sdk | 1.40.0 |
+| opentelemetry-instrumentation-fastapi | 0.61b0 |
+| opentelemetry-instrumentation-celery | 0.61b0 |
+| opentelemetry-instrumentation-sqlalchemy | 0.61b0 |
+| opentelemetry-exporter-otlp-proto-http | 1.40.0 |
+
+---
+
+## CLI and SDK Dependencies
+
+| Package | Version | License | Workspace |
+| --- | --- | --- | --- |
+| Typer | 0.24.1 | MIT | cli |
+| Rich | 14.3.3 | MIT | cli |
+| tomli-w | 1.2.0 | MIT | cli |
+| httpx | 0.28.1 | BSD-3-Clause | sdk |
+
+---
+
+## Monitoring
+
+| Package | Version | License | SPDX |
+| --- | --- | --- | --- |
+| Flower | 2.0.1 | BSD-3-Clause | `BSD-3-Clause` |
+
+Flower is an optional dependency
+(`backend/pyproject.toml [monitoring]`).
+
+---
+
+## Dev and Test Dependencies
+
+These are not shipped in production containers.
+
+| Package | Version | License | Usage |
+| --- | --- | --- | --- |
+| ruff | 0.15.7 | MIT | linter/formatter |
+| mypy | 1.19.1 | MIT | type checker |
+| pre-commit | 4.5.1 | MIT | git hooks |
+| pytest | 9.0.2 | MIT | test framework |
+| pytest-bdd | 8.1.0 | MIT | BDD testing |
+| pytest-asyncio | 1.3.0 | Apache 2.0 | async tests |
+| pytest-cov | 7.1.0 | MIT | coverage |
+| pytest-docker | 3.2.5 | MIT | Docker fixtures |
+| pytest-playwright | 0.7.2 | Apache 2.0 | browser tests |
+| factory-boy | 3.3.3 | MIT | test fixtures |
+| hatchling | 1.29.0 | MIT | build backend |
+| hatch | 1.16.5 | MIT | project manager |
+
+---
+
+## LLM Models
+
+Models are downloaded at runtime by the user via Ollama.
+OpenCase does not distribute any model weights.
+
+| Model | License | Notes |
+| --- | --- | --- |
+| Llama 3 8B | Meta Llama 3 Community License | Acceptable use policy; 700M MAU threshold |
+| Mistral 7B | Apache 2.0 | |
+| nomic-embed-text | Apache 2.0 | |
+
+---
+
+## Document Parsing (Planned)
+
+Not yet in the dependency tree. Will be added as Docker
+services or Python packages when document ingestion is
+implemented.
+
+| Component | License | SPDX |
+| --- | --- | --- |
+| Apache Tika | Apache 2.0 | `Apache-2.0` |
+| Tesseract OCR | Apache 2.0 | `Apache-2.0` |
+
+---
+
+## Frontend (Planned)
+
+The frontend is not yet implemented. These are the
+planned dependencies per the architecture spec.
+
+| Component | License | SPDX |
+| --- | --- | --- |
+| Next.js | MIT | `MIT` |
+| React | MIT | `MIT` |
+
+---
+
+## License Compatibility Analysis
+
+### Permissive licenses (no concerns)
+
+MIT, BSD-2-Clause, BSD-3-Clause, Apache 2.0, and the
+PostgreSQL License are all permissive and fully
+compatible with Apache 2.0 as the project license.
+Every directly-linked Python dependency falls into this
+category.
+
+### AGPL-3.0 (MinIO, Grafana OTEL-LGTM)
+
+MinIO and Grafana run as **separate network services**
+inside their own Docker containers. OpenCase communicates
+with them exclusively over TCP/HTTP. The AGPL's copyleft
+clause triggers when software is "conveyed" or when
+users interact with a "modified version" over a network.
+Because OpenCase does not modify, link against, or
+distribute AGPL source code, the copyleft obligation
+does not propagate to the OpenCase codebase.
+
+### LGPL-3.0 (psycopg2-binary)
+
+`psycopg2-binary` is a C extension dynamically loaded
+at runtime as a shared library. The LGPL explicitly
+permits dynamic linking without imposing copyleft on
+the calling application. OpenCase does not modify
+psycopg2 source code. The `-binary` wheel bundles
+`libpq`, which is PostgreSQL-licensed (permissive).
+
+### Redis server license (RSALv2 + SSPLv1)
+
+If `redis:7-alpine` resolves to Redis 7.4+, the server
+is under RSALv2 + SSPLv1. These licenses restrict
+offering Redis itself as a managed service but do not
+restrict applications that use Redis as an internal
+component. OpenCase uses Redis solely as a Celery
+broker and cache within its own Docker network.
+
+### Meta Llama 3 Community License
+
+OpenCase does not distribute Llama 3 model weights.
+Users download models themselves via Ollama. The Meta
+Llama 3 Community License has an acceptable use policy
+and a 700 million monthly active user threshold, neither
+of which applies to OpenCase's distribution of its own
+source code.
+
+### Attribution requirements
+
+Apache 2.0 and BSD licenses require retention of
+copyright and license notices. For Python packages
+installed via `pip` or `uv`, these notices are preserved
+in each package's `dist-info/LICENSE` directory inside
+the virtual environment. Docker images carry their own
+license terms independently. No additional `NOTICE` file
+is required at this time since OpenCase does not bundle
+or redistribute third-party source code in its own
+distribution artifacts.
+
+### Conclusion
+
+**Apache 2.0 is confirmed as a valid license for
+OpenCase.** All directly-linked dependencies are
+permissively licensed. Copyleft components (AGPL, LGPL)
+are isolated by architectural boundaries (network
+services, dynamic linking) that prevent license
+propagation. Model licenses do not apply because
+OpenCase does not distribute model weights.

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -44,5 +44,8 @@ BDD scenarios.*
 
 ### Legal Framework
 
+- [Third-Party Licenses](../LICENSING.md) — component
+  license inventory and compatibility analysis
+
 *Coming soon — jurisdiction-specific discovery rules,
 compliance references, and domain glossary.*


### PR DESCRIPTION
## Summary

- Add Apache 2.0 `LICENSE` file to repo root (resolves broken link in README)
- Create `LICENSING.md` inventorying all third-party component licenses across infrastructure services, Python runtime/dev/test dependencies, OTel stack, CLI/SDK, LLM models, and planned components
- Add compatibility analysis covering AGPL (MinIO, Grafana — network services only), LGPL (psycopg2-binary — dynamic linking), Redis 7.4+ relicensing, and Meta Llama 3 Community License
- Update `docs/TOC.md` with link under Legal Framework section

Closes #39

## Test plan

- [ ] Verify `LICENSE` link in README resolves correctly
- [ ] Verify `LICENSING.md` renders correctly on GitHub
- [ ] Verify `docs/TOC.md` link to `../LICENSING.md` works
- [ ] Spot-check dependency versions against `uv.lock`
- [ ] Review copyleft analysis for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)