### PR TITLE
feat: add Apache Tika container for document text extraction

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -208,6 +208,13 @@ def _minio_ready(host: str, port: int) -> bool:
         return False
 
 
+def _tika_ready(host: str, port: int) -> bool:
+    try:
+        return httpx.get(f"http://{host}:{port}/tika", timeout=2).status_code == 200
+    except httpx.HTTPError:
+        return False
+
+
 def _grafana_ready(host: str, port: int) -> bool:
     try:
         return httpx.get(f"http://{host}:{port}/", timeout=2).status_code == 200
@@ -271,6 +278,17 @@ def grafana_service(docker_ip, docker_services):
         check=lambda: _grafana_ready(docker_ip, 3001),
     )
     return f"http://{docker_ip}:3001"
+
+
+@pytest.fixture(scope="session")
+def tika_service(docker_ip, docker_services):
+    """Ensure Tika is up and return (host, port)."""
+    docker_services.wait_until_responsive(
+        timeout=60.0,
+        pause=0.5,
+        check=lambda: _tika_ready(docker_ip, 9998),
+    )
+    return docker_ip, 9998
 
 
 @pytest.fixture(scope="session")

--- a/infrastructure/docker-compose.integration.yml
+++ b/infrastructure/docker-compose.integration.yml
@@ -30,10 +30,18 @@ services:
     environment:
       - OPENCASE_DB_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/opencase_test
       - OPENCASE_CELERY_RESULT_BACKEND=db+postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/opencase_tasks_test
+      - OPENCASE_EXTRACTION_TIKA_URL=http://tika:9998
       - OPENCASE_OTEL_ENABLED=true
       - OPENCASE_OTEL_EXPORTER=otlp
       - OPENCASE_OTEL_ENDPOINT=http://grafana:4318
       - OPENCASE_OTEL_SERVICE_NAME=opencase-worker
+    depends_on:
+      tika:
+        condition: service_healthy
+
+  tika:
+    ports:
+      - "9998:9998"
 
   celery-beat:
     environment:

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -175,6 +175,7 @@ services:
       - "9998"
     healthcheck:
       test: ["CMD", "perl", "-e", "use IO::Socket::INET; my $$s = IO::Socket::INET->new(PeerAddr=>'localhost',PeerPort=>9998,Proto=>'tcp',Timeout=>2) or exit 1; print $$s \"GET /tika HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n\"; my $$r = <$$s>; exit($$r =~ /200/ ? 0 : 1);"]
+      start_period: 30s
       interval: 10s
       timeout: 5s
       retries: 5

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -168,6 +168,20 @@ services:
       - opencase
     restart: "no"
 
+  # --- Document Text Extraction -------------------------------
+  tika:
+    image: apache/tika:3.1.0.0
+    expose:
+      - "9998"
+    healthcheck:
+      test: ["CMD", "perl", "-e", "use IO::Socket::INET; my $$s = IO::Socket::INET->new(PeerAddr=>'localhost',PeerPort=>9998,Proto=>'tcp',Timeout=>2) or exit 1; print $$s \"GET /tika HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n\"; my $$r = <$$s>; exit($$r =~ /200/ ? 0 : 1);"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - opencase
+    restart: unless-stopped
+
   # --- Local LLM + Embeddings ------------------------------
   # Disabled until RAG pipeline implementation begins. Re-enable by
   # removing the profiles line or running: docker compose --profile rag up
@@ -266,6 +280,8 @@ services:
       - OPENCASE_S3_BUCKET=${OPENCASE_S3_BUCKET:-opencase}
       - OPENCASE_S3_USE_SSL=${OPENCASE_S3_USE_SSL:-false}
       - OPENCASE_S3_REGION=${OPENCASE_S3_REGION:-us-east-1}
+      # Document extraction (Tika)
+      - OPENCASE_EXTRACTION_TIKA_URL=${OPENCASE_EXTRACTION_TIKA_URL:-http://tika:9998}
       # Cloud ingestion (internet mode only)
       - AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-}
       - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET:-}
@@ -285,6 +301,8 @@ services:
         condition: service_healthy
       minio-init:
         condition: service_completed_successfully
+      tika:
+        condition: service_healthy
     networks:
       - opencase
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add Apache Tika 3.1.0.0 as a Docker Compose service (internal-only, no host port) with a Perl-based HTTP health check that verifies the `/tika` endpoint returns 200
- Wire `celery-worker` with `depends_on: tika: service_healthy` and `OPENCASE_EXTRACTION_TIKA_URL` env var
- Add `tika_service` pytest fixture and expose port 9998 in the integration test override

## Test plan
- [x] `docker compose config` validates cleanly for both base and integration overrides
- [x] Tika container starts and reports `healthy` within ~25s
- [x] Integration tests pass (42/47 — 5 pre-existing auth failures unrelated to this PR)
- [x] Pre-commit hooks pass (ruff, mypy, pytest)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)