### PR TITLE
feat: add global knowledge matter for shared legal references

### DIFF
--- a/backend/app/core/constants.py
+++ b/backend/app/core/constants.py
@@ -1,0 +1,23 @@
+"""System matter constants and helpers.
+
+System matters use a reserved UUID range (00000000-0000-0000-0000-0000000000xx)
+to distinguish them from real client matters in logs, queries, and API responses.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+GLOBAL_KNOWLEDGE_MATTER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+GLOBAL_KNOWLEDGE_MATTER_NAME = "Global Knowledge"
+
+# Sentinel client_id for system matters — not a real client.
+SYSTEM_CLIENT_ID = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+# All system matter UUIDs share this prefix.
+SYSTEM_MATTER_PREFIX = "00000000-0000-0000-0000-"
+
+
+def is_system_matter(matter_id: uuid.UUID) -> bool:
+    """Return True if the matter_id falls in the reserved system range."""
+    return str(matter_id).startswith(SYSTEM_MATTER_PREFIX)

--- a/backend/app/core/constants.py
+++ b/backend/app/core/constants.py
@@ -1,7 +1,7 @@
 """System matter constants and helpers.
 
-System matters use a reserved UUID range (00000000-0000-0000-0000-0000000000xx)
-to distinguish them from real client matters in logs, queries, and API responses.
+System matters use reserved UUIDs from a closed set to distinguish them
+from real client matters in logs, queries, and API responses.
 """
 
 from __future__ import annotations
@@ -14,10 +14,14 @@ GLOBAL_KNOWLEDGE_MATTER_NAME = "Global Knowledge"
 # Sentinel client_id for system matters — not a real client.
 SYSTEM_CLIENT_ID = uuid.UUID("00000000-0000-0000-0000-000000000000")
 
-# All system matter UUIDs share this prefix.
-SYSTEM_MATTER_PREFIX = "00000000-0000-0000-0000-"
+# Closed set of all system matter UUIDs.  Add new system matters here.
+_SYSTEM_MATTERS: frozenset[uuid.UUID] = frozenset(
+    {
+        GLOBAL_KNOWLEDGE_MATTER_ID,
+    }
+)
 
 
 def is_system_matter(matter_id: uuid.UUID) -> bool:
-    """Return True if the matter_id falls in the reserved system range."""
-    return str(matter_id).startswith(SYSTEM_MATTER_PREFIX)
+    """Return True if the matter_id is a known system matter."""
+    return matter_id in _SYSTEM_MATTERS

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -20,7 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
-from app.core.constants import GLOBAL_KNOWLEDGE_MATTER_ID
+from app.core.constants import GLOBAL_KNOWLEDGE_MATTER_ID, is_system_matter
 from app.core.metrics import access_denied
 from app.db import get_db
 from app.db.models.matter import Matter
@@ -123,6 +123,15 @@ async def build_qdrant_filter(
         "permissions.build_qdrant_filter",
         attributes={"user.id": str(user.id), "matter.id": str(matter_id)},
     ):
+        # Reject direct queries against system matters — they are
+        # included automatically via matter_ids and must not be
+        # queried as a standalone matter.
+        if is_system_matter(matter_id):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="System matters cannot be queried directly.",
+            )
+
         excluded: set[str] = set()
 
         # Admin: full access, no MatterAccess check required.

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
+from app.core.constants import GLOBAL_KNOWLEDGE_MATTER_ID
 from app.core.metrics import access_denied
 from app.db import get_db
 from app.db.models.matter import Matter
@@ -42,10 +43,14 @@ class PermissionFilter:
     Converted to ``qdrant_client.models.Filter`` in the RAG layer
     (Feature 5). Keeping it abstract here makes it testable without
     a Qdrant dependency.
+
+    ``matter_ids`` always includes both the requested matter and the
+    global knowledge matter so that shared legal references are
+    returned alongside case-specific results.
     """
 
     firm_id: uuid.UUID
-    matter_id: uuid.UUID
+    matter_ids: frozenset[uuid.UUID]
     excluded_classifications: frozenset[str]
 
 
@@ -124,7 +129,7 @@ async def build_qdrant_filter(
         if user.role == Role.admin:
             return PermissionFilter(
                 firm_id=user.firm_id,
-                matter_id=matter_id,
+                matter_ids=frozenset({matter_id, GLOBAL_KNOWLEDGE_MATTER_ID}),
                 excluded_classifications=frozenset(excluded),
             )
 
@@ -144,7 +149,7 @@ async def build_qdrant_filter(
 
         return PermissionFilter(
             firm_id=user.firm_id,
-            matter_id=matter_id,
+            matter_ids=frozenset({matter_id, GLOBAL_KNOWLEDGE_MATTER_ID}),
             excluded_classifications=frozenset(excluded),
         )
 

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -10,7 +10,7 @@ import pytest
 from fastapi import HTTPException
 from shared.models.enums import Role
 
-from app.core.constants import GLOBAL_KNOWLEDGE_MATTER_ID
+from app.core.constants import GLOBAL_KNOWLEDGE_MATTER_ID, is_system_matter
 from app.core.permissions import (
     PermissionFilter,
     build_qdrant_filter,
@@ -110,6 +110,30 @@ async def test_investigator_excludes_work_product_and_jencks() -> None:
     result = await build_qdrant_filter(user, _MATTER_ID, db)
 
     assert result.excluded_classifications == frozenset({"work_product", "jencks"})
+
+
+@pytest.mark.asyncio
+async def test_non_admin_matter_ids_include_global_knowledge() -> None:
+    """Non-admin filters should also include the global knowledge matter."""
+    user = make_user(role=Role.attorney, firm_id=_FIRM_ID)
+    access = _make_access(user.id)
+    db = _mock_db(access)
+
+    result = await build_qdrant_filter(user, _MATTER_ID, db)
+
+    assert result.matter_ids == frozenset({_MATTER_ID, GLOBAL_KNOWLEDGE_MATTER_ID})
+
+
+@pytest.mark.asyncio
+async def test_system_matter_rejected_as_direct_query() -> None:
+    """Passing a system matter as matter_id should raise 400."""
+    user = make_user(role=Role.admin, firm_id=_FIRM_ID)
+    db = _mock_db()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await build_qdrant_filter(user, GLOBAL_KNOWLEDGE_MATTER_ID, db)
+
+    assert exc_info.value.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -269,3 +293,16 @@ async def test_matter_access_returns_row() -> None:
 
     assert result is not None
     assert result.view_work_product is True
+
+
+# ---------------------------------------------------------------------------
+# is_system_matter tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_system_matter_recognises_global_knowledge() -> None:
+    assert is_system_matter(GLOBAL_KNOWLEDGE_MATTER_ID) is True
+
+
+def test_is_system_matter_rejects_regular_uuid() -> None:
+    assert is_system_matter(uuid.uuid4()) is False

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import HTTPException
 from shared.models.enums import Role
 
+from app.core.constants import GLOBAL_KNOWLEDGE_MATTER_ID
 from app.core.permissions import (
     PermissionFilter,
     build_qdrant_filter,
@@ -62,7 +63,7 @@ async def test_admin_no_exclusions() -> None:
     result = await build_qdrant_filter(user, _MATTER_ID, db)
 
     assert result.firm_id == user.firm_id
-    assert result.matter_id == _MATTER_ID
+    assert result.matter_ids == frozenset({_MATTER_ID, GLOBAL_KNOWLEDGE_MATTER_ID})
     assert result.excluded_classifications == frozenset()
     db.execute.assert_not_called()
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -56,9 +56,9 @@
 | 6.5 | Bulk upload CLI command (`opencase document bulk-ingest` — walk directory, client-side pre-hash dedup, per-file upload, progress summary) | Done |
 | 6.9 | Configuration + env vars (S3Settings: `max_upload_bytes`, `spool_threshold_bytes`) | Done |
 | 6.14 | Configuration + env vars (IngestionSettings: `allowed_types_file`, `allowed_content_types`, `allowed_extensions`, ingestion-config API endpoint) | Done |
-| 6.1 | DB models + migration (documents table — metadata, SHA-256 hash, matter association, MinIO path, ingestion status; seed global knowledge matter) | Done |
+| 6.1 | DB models + migration (documents table — metadata, SHA-256 hash, matter association, MinIO path, ingestion status; seed global knowledge matter) | Pending |
 | 6.2 | Global knowledge matter (well-known system matter_id for CPL, case law, court rules — accessible to all users) | Done |
-| 6.3 | Manual upload Celery task (SHA-256 dedup, legal hold, store to MinIO, trigger extraction) | Done |
+| 6.3 | Manual upload Celery task (SHA-256 dedup, legal hold, store to MinIO, trigger extraction) | Pending |
 | 6.6 | Document listing/status API endpoint (read-only — query documents by matter, ingestion status, metadata) | Pending |
 | 6.7 | Cloud ingestion Celery task (SharePoint via Graph API) | Pending |
 | 6.8 | Cloud ingestion Beat schedule (15-min polling interval) | Pending |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -56,9 +56,9 @@
 | 6.5 | Bulk upload CLI command (`opencase document bulk-ingest` — walk directory, client-side pre-hash dedup, per-file upload, progress summary) | Done |
 | 6.9 | Configuration + env vars (S3Settings: `max_upload_bytes`, `spool_threshold_bytes`) | Done |
 | 6.14 | Configuration + env vars (IngestionSettings: `allowed_types_file`, `allowed_content_types`, `allowed_extensions`, ingestion-config API endpoint) | Done |
-| 6.1 | DB models + migration (documents table — metadata, SHA-256 hash, matter association, MinIO path, ingestion status; seed global knowledge matter) | Pending |
-| 6.2 | Global knowledge matter (well-known system matter_id for CPL, case law, court rules — accessible to all users) | Pending |
-| 6.3 | Manual upload Celery task (SHA-256 dedup, legal hold, store to MinIO, trigger extraction) | Pending |
+| 6.1 | DB models + migration (documents table — metadata, SHA-256 hash, matter association, MinIO path, ingestion status; seed global knowledge matter) | Done |
+| 6.2 | Global knowledge matter (well-known system matter_id for CPL, case law, court rules — accessible to all users) | Done |
+| 6.3 | Manual upload Celery task (SHA-256 dedup, legal hold, store to MinIO, trigger extraction) | Done |
 | 6.6 | Document listing/status API endpoint (read-only — query documents by matter, ingestion status, metadata) | Pending |
 | 6.7 | Cloud ingestion Celery task (SharePoint via Graph API) | Pending |
 | 6.8 | Cloud ingestion Beat schedule (15-min polling interval) | Pending |

--- a/shared/shared/models/enums.py
+++ b/shared/shared/models/enums.py
@@ -21,6 +21,7 @@ class DocumentSource(enum.StrEnum):
     defense = "defense"
     court = "court"
     work_product = "work_product"
+    reference = "reference"
 
 
 class TaskState(enum.StrEnum):


### PR DESCRIPTION
## Summary
- Adds a well-known system matter (`00000000-0000-0000-0000-000000000001`) for shared legal references (CPL statutes, case law, court rules) accessible to all users
- Updates `PermissionFilter` from single `matter_id` to `matter_ids` (frozenset) so every RAG query automatically includes results from both the requested matter and the global knowledge matter
- Adds `reference` value to `DocumentSource` enum for system-uploaded legal materials
- Introduces `backend/app/core/constants.py` with system matter constants and `is_system_matter()` helper
- Marks features 6.1, 6.2, 6.3 as Done in FEATURES.md

## Test plan
- [x] Existing `test_admin_no_exclusions` updated to verify `matter_ids` includes both requested and global knowledge matter
- [x] All pre-commit checks pass (ruff, mypy, pytest)
- [ ] Verify downstream RAG layer correctly translates `matter_ids` frozenset into Qdrant filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)