### PR TITLE
feat: document listing filters, pagination, sorting & re-ingest endpoint (#69)

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -409,10 +409,13 @@ async def list_documents(
         if classification is not None:
             stmt = stmt.where(Document.classification == classification)
         if filename is not None:
-            safe = filename.replace("%", r"\%").replace("_", r"\_")
-            stmt = stmt.where(Document.filename.ilike(f"%{safe}%", escape="\\"))
+            escaped_filename = filename.replace("%", r"\%").replace("_", r"\_")
+            stmt = stmt.where(
+                Document.filename.ilike(f"%{escaped_filename}%", escape="\\")
+            )
 
-        # Count total before pagination
+        # Count total before pagination (must run before ORDER BY is applied
+        # to avoid PostgreSQL requiring ORDER BY expressions in the SELECT list)
         count_stmt = select(func.count()).select_from(stmt.subquery())
         total = (await db.execute(count_stmt)).scalar_one()
 
@@ -528,7 +531,26 @@ async def re_ingest_document(
         "documents.re_ingest",
         attributes={"user.id": str(user.id), "document.id": str(document_id)},
     ):
-        doc = await _get_document_with_access(document_id, user, db)
+        # Re-ingest is a write operation — restrict to admin and attorney
+        if user.role not in (Role.admin, Role.attorney):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only admins and attorneys can re-ingest documents",
+            )
+
+        # Lock the row to prevent concurrent re-ingest races
+        result = await db.execute(
+            select(Document)
+            .where(
+                Document.id == document_id,
+                Document.firm_id == user.firm_id,
+            )
+            .with_for_update()
+        )
+        doc = result.scalar_one_or_none()
+        if doc is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+        await _verify_matter_access(doc.matter_id, user, db)
 
         if doc.legal_hold:
             raise HTTPException(

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -6,6 +6,7 @@ import logging
 import re
 import uuid
 from pathlib import PurePosixPath
+from typing import Literal
 from urllib.parse import quote
 
 from fastapi import (
@@ -21,13 +22,15 @@ from fastapi import (
 from fastapi.responses import Response
 from opentelemetry import trace
 from shared.models.document import (
+    DocumentListResponse,
     DocumentResponse,
     DocumentSummary,
     DuplicateCheckResponse,
     IngestionConfigResponse,
+    ReIngestResponse,
 )
 from shared.models.enums import Classification, DocumentSource, IngestionStatus, Role
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -353,16 +356,34 @@ async def check_duplicate(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/", response_model=list[DocumentSummary])
+_SORTABLE_COLUMNS = {
+    "created_at": Document.created_at,
+    "filename": Document.filename,
+    "size_bytes": Document.size_bytes,
+    "updated_at": Document.updated_at,
+}
+
+
+@router.get("/", response_model=DocumentListResponse)
 async def list_documents(
     matter_id: uuid.UUID | None = Query(None),  # noqa: B008
+    ingestion_status: IngestionStatus | None = Query(None),  # noqa: B008
+    source: DocumentSource | None = Query(None),  # noqa: B008
+    classification: Classification | None = Query(None),  # noqa: B008
+    filename: str | None = Query(None),  # noqa: B008
+    offset: int = Query(0, ge=0),  # noqa: B008
+    limit: int = Query(50, ge=1, le=200),  # noqa: B008
+    sort_by: Literal[  # noqa: B008
+        "created_at", "filename", "size_bytes", "updated_at"
+    ] = Query("created_at"),
+    sort_order: Literal["asc", "desc"] = Query("desc"),  # noqa: B008
     user: User = Depends(get_current_user),  # noqa: B008
     db: AsyncSession = Depends(get_db),  # noqa: B008
-) -> list[DocumentSummary]:
+) -> DocumentListResponse:
     """List documents accessible to the current user.
 
-    Optionally filter by ``matter_id``. Non-admin users only see documents
-    in matters they have been granted access to.
+    Supports filtering by matter, ingestion status, source, classification,
+    and filename (partial, case-insensitive). Results are paginated.
     """
     with tracer.start_as_current_span(
         "documents.list",
@@ -374,17 +395,42 @@ async def list_documents(
             await _verify_matter_access(matter_id, user, db)
             stmt = stmt.where(Document.matter_id == matter_id)
         elif user.role != Role.admin:
-            # Non-admin without explicit matter_id: scope to accessible matters
             stmt = stmt.join(
                 MatterAccess,
                 (MatterAccess.matter_id == Document.matter_id)
                 & (MatterAccess.user_id == user.id),
             )
 
-        stmt = stmt.order_by(Document.created_at.desc())
+        # Apply filters
+        if ingestion_status is not None:
+            stmt = stmt.where(Document.ingestion_status == ingestion_status)
+        if source is not None:
+            stmt = stmt.where(Document.source == source)
+        if classification is not None:
+            stmt = stmt.where(Document.classification == classification)
+        if filename is not None:
+            safe = filename.replace("%", r"\%").replace("_", r"\_")
+            stmt = stmt.where(Document.filename.ilike(f"%{safe}%", escape="\\"))
+
+        # Count total before pagination
+        count_stmt = select(func.count()).select_from(stmt.subquery())
+        total = (await db.execute(count_stmt)).scalar_one()
+
+        # Sorting
+        col = _SORTABLE_COLUMNS[sort_by]
+        stmt = stmt.order_by(col.desc() if sort_order == "desc" else col.asc())
+
+        # Pagination
+        stmt = stmt.offset(offset).limit(limit)
+
         result = await db.execute(stmt)
         docs = result.scalars().all()
-        return [_doc_to_summary(d) for d in docs]
+        return DocumentListResponse(
+            items=[_doc_to_summary(d) for d in docs],
+            total=total,
+            offset=offset,
+            limit=limit,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -454,4 +500,78 @@ async def download_document(
                     f"filename*=UTF-8''{encoded_name}"
                 ),
             },
+        )
+
+
+# ---------------------------------------------------------------------------
+# POST /documents/{document_id}/re-ingest
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{document_id}/re-ingest",
+    response_model=ReIngestResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    responses={404: {}, 409: {}},
+)
+async def re_ingest_document(
+    document_id: uuid.UUID,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> ReIngestResponse:
+    """Re-ingest a document that previously failed ingestion.
+
+    Only documents with ``ingestion_status = failed`` can be re-ingested.
+    Resets the status to ``pending`` and dispatches a new ingestion task.
+    """
+    with tracer.start_as_current_span(
+        "documents.re_ingest",
+        attributes={"user.id": str(user.id), "document.id": str(document_id)},
+    ):
+        doc = await _get_document_with_access(document_id, user, db)
+
+        if doc.legal_hold:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Cannot re-ingest a document under legal hold",
+            )
+
+        if doc.ingestion_status != IngestionStatus.failed:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Only failed documents can be re-ingested; "
+                    f"current status is '{doc.ingestion_status.value}'"
+                ),
+            )
+
+        # Reset to pending
+        doc.ingestion_status = IngestionStatus.pending
+        await db.commit()
+        await db.refresh(doc)
+
+        # Reconstruct S3 key and dispatch ingestion
+        extension = _extension_from_filename(doc.filename)
+        s3_key = S3StorageService.object_key(
+            doc.firm_id, doc.matter_id, doc.id, extension
+        )
+
+        try:
+            from app.ingestion import get_ingestion_service
+
+            ingestion = get_ingestion_service()
+            await ingestion.process_document(doc.id, s3_key)
+        except Exception:
+            logger.exception("Re-ingest dispatch failed for document %s", doc.id)
+            doc.ingestion_status = IngestionStatus.failed
+            await db.commit()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to dispatch ingestion task",
+            ) from None
+
+        return ReIngestResponse(
+            document_id=doc.id,
+            ingestion_status=doc.ingestion_status,
+            message="Ingestion task submitted",
         )

--- a/backend/app/workers/tasks/ingest_document.py
+++ b/backend/app/workers/tasks/ingest_document.py
@@ -47,9 +47,18 @@ async def _update_ingestion_status(document_id: str, status: IngestionStatus) ->
                     document_id,
                 )
                 return
-            if doc.ingestion_status in (
-                IngestionStatus.indexed,
-                IngestionStatus.failed,
+            # Allow failed → pending (re-ingest); block other regressions
+            if doc.ingestion_status == IngestionStatus.indexed:
+                logger.warning(
+                    "_update_ingestion_status: refusing to regress %s from %s to %s",
+                    document_id,
+                    doc.ingestion_status,
+                    status,
+                )
+                return
+            if (
+                doc.ingestion_status == IngestionStatus.failed
+                and status != IngestionStatus.pending
             ):
                 logger.warning(
                     "_update_ingestion_status: refusing to regress %s from %s to %s",
@@ -79,6 +88,26 @@ def ingest_document(document_id: str, s3_key: str) -> dict[str, object]:
     return asyncio.run(_ingest(document_id, s3_key))
 
 
+async def _check_legal_hold(document_id: str) -> bool:
+    """Return True if the document is under legal hold.
+
+    Reuses the same engine-per-call pattern as ``_update_ingestion_status``
+    and ``_run_metadata_lookup`` to avoid event-loop conflicts in Celery.
+    """
+    from app.db.models.document import Document
+
+    engine = create_async_engine(settings.db.url, pool_pre_ping=True)
+    try:
+        async with AsyncSession(engine) as session:
+            doc = await session.get(Document, document_id)
+            if doc is None:
+                logger.warning("_check_legal_hold: document %s not found", document_id)
+                return False
+            return bool(doc.legal_hold)
+    finally:
+        await engine.dispose()
+
+
 async def _ingest(document_id: str, s3_key: str) -> dict[str, object]:
     with tracer.start_as_current_span(
         "ingest_document",
@@ -89,6 +118,20 @@ async def _ingest(document_id: str, s3_key: str) -> dict[str, object]:
         },
     ) as span:
         try:
+            # Legal hold guard — skip ingestion for held documents
+            if await _check_legal_hold(document_id):
+                logger.warning(
+                    "ingest_document skipped: document %s is under legal hold",
+                    document_id,
+                )
+                span.set_attribute("ingestion.skipped", True)
+                span.set_attribute("ingestion.skip_reason", "legal_hold")
+                return {
+                    "status": "skipped",
+                    "reason": "legal_hold",
+                    "document_id": document_id,
+                }
+
             s3_prefix = s3_key.rsplit("/", 1)[0]
 
             await _update_ingestion_status(document_id, IngestionStatus.extracting)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -89,13 +89,16 @@ class FakeSession:
             if isinstance(val, list):
                 result.scalars.return_value.all.return_value = val
                 result.scalar_one_or_none.return_value = val[0] if val else None
+                result.scalar_one.return_value = val[0] if val else None
             else:
                 result.scalar_one_or_none.return_value = val
+                result.scalar_one.return_value = val
                 result.scalars.return_value.all.return_value = (
                     [val] if val is not None else []
                 )
         else:
             result.scalar_one_or_none.return_value = None
+            result.scalar_one.return_value = None
             result.scalars.return_value.all.return_value = []
         return result
 
@@ -146,6 +149,14 @@ def auth_header(user: User) -> dict[str, str]:
     """Return an Authorization header dict for the given user."""
     token = create_access_token(user)
     return {"Authorization": f"Bearer {token}"}
+
+
+def fake_with_docs(docs: list, total: int | None = None) -> FakeSession:
+    """Create a FakeSession pre-loaded with count + docs results for list endpoints."""
+    fake = FakeSession()
+    fake.add_result(total if total is not None else len(docs))  # count query
+    fake.add_results_list(docs)  # main query
+    return fake
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_document_listing.py
+++ b/backend/tests/test_document_listing.py
@@ -1,0 +1,189 @@
+"""Unit tests for document listing endpoint — filters, pagination, sorting."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from shared.models.enums import (
+    Classification,
+    DocumentSource,
+    IngestionStatus,
+    Role,
+)
+
+from tests.conftest import FakeSession, api_client, auth_header, fake_with_docs
+from tests.factories import make_document, make_user
+
+_FIRM_ID = uuid.uuid4()
+_MATTER_ID = uuid.uuid4()
+
+
+class TestListDocumentsFilters:
+    @pytest.mark.asyncio
+    async def test_filter_by_ingestion_status(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(
+            firm_id=_FIRM_ID,
+            matter_id=_MATTER_ID,
+            uploaded_by=user.id,
+            ingestion_status=IngestionStatus.failed,
+        )
+        fake = fake_with_docs([doc])
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(
+                "/documents/",
+                params={"ingestion_status": "failed"},
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["ingestion_status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_source(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(
+            firm_id=_FIRM_ID,
+            matter_id=_MATTER_ID,
+            uploaded_by=user.id,
+            source=DocumentSource.government_production,
+        )
+        fake = fake_with_docs([doc])
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(
+                "/documents/",
+                params={"source": "government_production"},
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 200
+        assert len(resp.json()["items"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_by_classification(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(
+            firm_id=_FIRM_ID,
+            matter_id=_MATTER_ID,
+            uploaded_by=user.id,
+            classification=Classification.brady,
+        )
+        fake = fake_with_docs([doc])
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(
+                "/documents/",
+                params={"classification": "brady"},
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 200
+        assert len(resp.json()["items"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_by_filename(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(
+            firm_id=_FIRM_ID,
+            matter_id=_MATTER_ID,
+            uploaded_by=user.id,
+            filename="evidence_photo.jpg",
+        )
+        fake = fake_with_docs([doc])
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(
+                "/documents/",
+                params={"filename": "evidence"},
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 200
+        assert len(resp.json()["items"]) == 1
+
+
+class TestListDocumentsPagination:
+    @pytest.mark.asyncio
+    async def test_pagination_offset_limit(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(firm_id=_FIRM_ID, matter_id=_MATTER_ID, uploaded_by=user.id)
+        # total=5 but only 1 doc in this page
+        fake = fake_with_docs([doc], total=5)
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(
+                "/documents/",
+                params={"offset": 2, "limit": 1},
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["offset"] == 2
+        assert data["limit"] == 1
+        assert data["total"] == 5
+
+    @pytest.mark.asyncio
+    async def test_default_pagination(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = fake_with_docs([])
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.get("/documents/", headers=auth_header(user))
+
+        data = resp.json()
+        assert data["offset"] == 0
+        assert data["limit"] == 50
+
+    @pytest.mark.asyncio
+    async def test_limit_validation_max(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(
+                "/documents/",
+                params={"limit": 999},
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 422
+
+
+class TestListDocumentsSorting:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "sort_by", ["created_at", "filename", "size_bytes", "updated_at"]
+    )
+    async def test_valid_sort_fields(self, sort_by: str) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = fake_with_docs([])
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(
+                "/documents/",
+                params={"sort_by": sort_by},
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("sort_order", ["asc", "desc"])
+    async def test_sort_order(self, sort_order: str) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = fake_with_docs([])
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.get(
+                "/documents/",
+                params={"sort_order": sort_order},
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 200

--- a/backend/tests/test_document_prompt_endpoints.py
+++ b/backend/tests/test_document_prompt_endpoints.py
@@ -14,7 +14,7 @@ import pytest
 from shared.models.enums import Role
 
 from app.storage import get_storage_service
-from tests.conftest import FakeSession, api_client, auth_header
+from tests.conftest import FakeSession, api_client, auth_header, fake_with_docs
 from tests.factories import make_document, make_user
 
 # ---------------------------------------------------------------------------
@@ -149,24 +149,28 @@ class TestListDocuments:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_no_documents(self) -> None:
         user = make_user(firm_id=_FIRM_ID, role=Role.admin)
-        fake = FakeSession()
+        fake = fake_with_docs([])
         async with api_client(user, fake) as ac:
             resp = await ac.get("/documents/", headers=auth_header(user))
         assert resp.status_code == 200
-        assert resp.json() == []
+        data = resp.json()
+        assert data["items"] == []
+        assert data["total"] == 0
 
     @pytest.mark.asyncio
     async def test_returns_documents_for_admin(self) -> None:
         user = make_user(firm_id=_FIRM_ID, role=Role.admin)
         doc = make_document(firm_id=_FIRM_ID, matter_id=_MATTER_ID, uploaded_by=user.id)
-        fake = FakeSession()
-        fake.add_results_list([doc])
+        fake = fake_with_docs([doc])
         async with api_client(user, fake) as ac:
             resp = await ac.get("/documents/", headers=auth_header(user))
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["id"] == str(doc.id)
+        assert len(data["items"]) == 1
+        assert data["items"][0]["id"] == str(doc.id)
+        assert data["total"] == 1
+        assert data["offset"] == 0
+        assert data["limit"] == 50
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_extraction_observability.py
+++ b/backend/tests/test_extraction_observability.py
@@ -240,6 +240,7 @@ class TestIngestDocumentSpans:
             source="defense",
             bates_number=None,
             ingestion_status="pending",
+            legal_hold=False,
         )
         mock_matter = SimpleNamespace(client_id="client-1")
 

--- a/backend/tests/test_reingest_endpoint.py
+++ b/backend/tests/test_reingest_endpoint.py
@@ -1,0 +1,209 @@
+"""Unit tests for the re-ingest endpoint and legal hold guard."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from shared.models.enums import IngestionStatus, Role
+
+from tests.conftest import FakeSession, api_client, auth_header
+from tests.factories import make_document, make_user
+
+_FIRM_ID = uuid.uuid4()
+_MATTER_ID = uuid.uuid4()
+
+
+# ---------------------------------------------------------------------------
+# POST /documents/{document_id}/re-ingest
+# ---------------------------------------------------------------------------
+
+
+class TestReIngest:
+    @pytest.mark.asyncio
+    async def test_re_ingest_failed_document_returns_202(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(
+            firm_id=_FIRM_ID,
+            matter_id=_MATTER_ID,
+            uploaded_by=user.id,
+            ingestion_status=IngestionStatus.failed,
+        )
+        fake = FakeSession()
+        fake.add_result(doc)  # _get_document_with_access
+
+        with patch("app.ingestion.get_ingestion_service") as mock_ingest:
+            mock_ingest.return_value = MagicMock(process_document=AsyncMock())
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    f"/documents/{doc.id}/re-ingest",
+                    headers=auth_header(user),
+                )
+
+        assert resp.status_code == 202
+        data = resp.json()
+        assert data["document_id"] == str(doc.id)
+        assert data["ingestion_status"] == "pending"
+        assert data["message"] == "Ingestion task submitted"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status",
+        [
+            IngestionStatus.pending,
+            IngestionStatus.extracting,
+            IngestionStatus.chunking,
+            IngestionStatus.embedding,
+            IngestionStatus.indexed,
+        ],
+    )
+    async def test_re_ingest_non_failed_returns_409(
+        self, status: IngestionStatus
+    ) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(
+            firm_id=_FIRM_ID,
+            matter_id=_MATTER_ID,
+            uploaded_by=user.id,
+            ingestion_status=status,
+        )
+        fake = FakeSession()
+        fake.add_result(doc)
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.post(
+                f"/documents/{doc.id}/re-ingest",
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_re_ingest_not_found_returns_404(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        # No result queued → scalar_one_or_none returns None → 404
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.post(
+                f"/documents/{uuid.uuid4()}/re-ingest",
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_re_ingest_legal_hold_returns_409(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(
+            firm_id=_FIRM_ID,
+            matter_id=_MATTER_ID,
+            uploaded_by=user.id,
+            ingestion_status=IngestionStatus.failed,
+            legal_hold=True,
+        )
+        fake = FakeSession()
+        fake.add_result(doc)
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.post(
+                f"/documents/{doc.id}/re-ingest",
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 409
+        assert "legal hold" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_re_ingest_dispatch_failure_returns_500(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        doc = make_document(
+            firm_id=_FIRM_ID,
+            matter_id=_MATTER_ID,
+            uploaded_by=user.id,
+            ingestion_status=IngestionStatus.failed,
+        )
+        fake = FakeSession()
+        fake.add_result(doc)
+
+        with patch("app.ingestion.get_ingestion_service") as mock_ingest:
+            mock_ingest.return_value = MagicMock(
+                process_document=AsyncMock(side_effect=RuntimeError("broker down"))
+            )
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    f"/documents/{doc.id}/re-ingest",
+                    headers=auth_header(user),
+                )
+
+        assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Legal hold guard in ingest_document task
+# ---------------------------------------------------------------------------
+
+
+class TestLegalHoldGuard:
+    @pytest.mark.asyncio
+    async def test_legal_hold_skips_ingestion(self) -> None:
+        """When a document has legal_hold=True, _ingest returns skipped."""
+        from app.workers.tasks.ingest_document import _ingest
+
+        doc_id = str(uuid.uuid4())
+        s3_key = f"firm/matter/{doc_id}/original.pdf"
+
+        with patch(
+            "app.workers.tasks.ingest_document._check_legal_hold",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await _ingest(doc_id, s3_key)
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "legal_hold"
+        assert result["document_id"] == doc_id
+
+    @pytest.mark.asyncio
+    async def test_no_legal_hold_proceeds(self) -> None:
+        """When legal_hold=False, ingestion proceeds (we mock the rest)."""
+        from app.workers.tasks.ingest_document import _ingest
+
+        doc_id = str(uuid.uuid4())
+        s3_key = f"firm/matter/{doc_id}/original.pdf"
+
+        with (
+            patch(
+                "app.workers.tasks.ingest_document._check_legal_hold",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "app.workers.tasks.ingest_document._update_ingestion_status",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.workers.tasks.ingest_document._run_extract",
+                new_callable=AsyncMock,
+            ) as mock_extract,
+            patch(
+                "app.workers.tasks.ingest_document._run_metadata_lookup",
+                new_callable=AsyncMock,
+                return_value={"firm_id": "f", "matter_id": "m", "client_id": "c"},
+            ),
+            patch(
+                "app.workers.tasks.ingest_document._run_chunking",
+                new_callable=AsyncMock,
+                return_value=[{"text": "chunk"}],
+            ),
+            patch(
+                "app.workers.tasks.ingest_document._run_embedding",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+        ):
+            mock_extract.return_value = MagicMock(text="hello world")
+            result = await _ingest(doc_id, s3_key)
+
+        assert result["status"] == "completed"

--- a/backend/tests/test_reingest_endpoint.py
+++ b/backend/tests/test_reingest_endpoint.py
@@ -139,6 +139,20 @@ class TestReIngest:
 
         assert resp.status_code == 500
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", [Role.paralegal, Role.investigator])
+    async def test_re_ingest_forbidden_for_non_admin_attorney(self, role: Role) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=role)
+        fake = FakeSession()
+
+        async with api_client(user, fake) as ac:
+            resp = await ac.post(
+                f"/documents/{uuid.uuid4()}/re-ingest",
+                headers=auth_header(user),
+            )
+
+        assert resp.status_code == 403
+
 
 # ---------------------------------------------------------------------------
 # Legal hold guard in ingest_document task

--- a/backend/tests/test_workers.py
+++ b/backend/tests/test_workers.py
@@ -165,6 +165,7 @@ def test_ingest_document_full_pipeline():
         source="defense",
         bates_number=None,
         ingestion_status="pending",
+        legal_hold=False,
     )
     mock_matter = SimpleNamespace(client_id="client-1")
 

--- a/shared/shared/models/document.py
+++ b/shared/shared/models/document.py
@@ -37,6 +37,23 @@ class DocumentResponse(DocumentSummary):
     updated_at: datetime
 
 
+class DocumentListResponse(BaseModel):
+    """Paginated document listing."""
+
+    items: list[DocumentSummary]
+    total: int
+    offset: int
+    limit: int
+
+
+class ReIngestResponse(BaseModel):
+    """Response from re-ingest endpoint."""
+
+    document_id: UUID
+    ingestion_status: IngestionStatus
+    message: str
+
+
 class DuplicateCheckResponse(BaseModel):
     """Result of a duplicate-check query against a matter."""
 


### PR DESCRIPTION
## Summary
- **GET /documents/** — Add query filters (`ingestion_status`, `source`, `classification`, `filename`), pagination (`offset`/`limit` with `total` count), and sorting (`sort_by`, `sort_order`) with validated `Literal` types
- **POST /documents/{id}/re-ingest** — Retry failed ingestions; checks legal hold at API level, rolls back to `failed` on dispatch error, returns 409 for non-failed or legally held documents
- **Worker legal hold guard** — `_ingest` skips documents under legal hold with observability span attributes
- **Security** — Escape LIKE wildcards in filename filter to prevent pattern injection; validate sort params with `Literal` types; `raise ... from None` for proper exception chaining
- **Shared test helpers** — Promote `fake_with_docs` to `conftest.py`; remove unused imports

## Test plan
- [x] `test_document_listing.py` — filters (status, source, classification, filename), pagination (offset/limit, defaults, max validation), sorting (all fields, both orders)
- [x] `test_reingest_endpoint.py` — happy path 202, non-failed 409, not-found 404, legal hold 409, dispatch failure 500
- [x] `test_reingest_endpoint.py` — legal hold guard in worker (_ingest skips, proceeds when not held)
- [x] Existing `test_document_prompt_endpoints.py` updated for paginated response shape
- [x] All 37 tests pass; pre-commit hooks (ruff, mypy, pytest) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)