### PR TITLE
fix: pass Celery time limits to worker and add Flower broker_api

### DIFF
--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -328,6 +328,9 @@ services:
       - OPENCASE_DB_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - OPENCASE_CELERY_BROKER_URL=redis://redis:6379/0
       - OPENCASE_CELERY_RESULT_BACKEND=db+postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/opencase_tasks
+      - OPENCASE_CELERY_TASK_SOFT_TIME_LIMIT=${OPENCASE_CELERY_TASK_SOFT_TIME_LIMIT:-300}
+      - OPENCASE_CELERY_TASK_HARD_TIME_LIMIT=${OPENCASE_CELERY_TASK_HARD_TIME_LIMIT:-600}
+      - OPENCASE_CELERY_WORKER_CONCURRENCY=${OPENCASE_CELERY_WORKER_CONCURRENCY:-2}
       - OPENCASE_LOG_LEVEL=${OPENCASE_LOG_LEVEL:-INFO}
       - OPENCASE_LOG_OUTPUT=${OPENCASE_LOG_OUTPUT:-stdout}
       - OPENCASE_DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-airgapped}
@@ -417,7 +420,7 @@ services:
       dockerfile: backend/docker/Dockerfile
       args:
         INSTALL_EXTRAS: monitoring
-    command: celery -A app.workers flower --port=5555 --url_prefix=/flower
+    command: celery -A app.workers flower --port=5555 --url_prefix=/flower --broker_api=redis://redis:6379/0
     ports:
       - "${OPENCASE_FLOWER_PORT:-5555}:5555"
     environment:


### PR DESCRIPTION
## Summary
- Forward `OPENCASE_CELERY_TASK_SOFT_TIME_LIMIT`, `OPENCASE_CELERY_TASK_HARD_TIME_LIMIT`, and `OPENCASE_CELERY_WORKER_CONCURRENCY` from `.env` to the Celery worker container
- Add `--broker_api=redis://redis:6379/0` to Flower command so the Broker tab displays queue depth and message counts

Closes #77

## Test plan
- [x] Worker picks up timeout values from `.env` (verified: `soft=900, hard=1200`)
- [x] Flower Broker tab shows `celery` queue with message count
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)