### PR TITLE
chore: rename project to Gideon and add utility scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,17 @@
-# OpenCase — Claude Code Context
+# Gideon — Claude Code Context
 
 ## Project Mission
 
-OpenCase is a free, fully self-hostable, AI-powered
+Gideon is a free, fully self-hostable, AI-powered
 discovery platform for solo and small criminal defense
 practitioners. It runs entirely on-premise with no
 third-party LLM API calls, protecting client
 confidentiality under ABA Rules 1.6 and 1.1.
+
+The project is named after *Gideon v. Wainwright* (1963),
+the Supreme Court decision establishing the right to
+counsel for criminal defendants who cannot afford an
+attorney.
 
 Primary design partner: **Virginia Cora, Cora Firm**
 (solo criminal defense, New York).
@@ -19,7 +24,7 @@ License: **Apache 2.0**
 
 ### Deployment Model
 
-- **Single-tenant**: one OpenCase instance per firm
+- **Single-tenant**: one Gideon instance per firm
 - **Two modes**:
   - *Air-gapped*: manual upload only, no external
     network calls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenCase
+# Gideon
 
 **Open source criminal defense discovery platform.**
 
@@ -8,12 +8,24 @@ practitioners. Runs entirely on-premise with no
 third-party LLM API calls, protecting client
 confidentiality under ABA Rules 1.6 and 1.1.
 
-## Why OpenCase?
+Named after *Gideon v. Wainwright* (1963) — the Supreme
+Court decision establishing the right to counsel for
+criminal defendants who cannot afford an attorney.
+
+## Release Naming Convention
+
+Major releases are named after famous jurists:
+
+| Version | Codename | Jurist |
+| --- | --- | --- |
+| v1 | Ginsburg | Ruth Bader Ginsburg |
+
+## Why Gideon?
 
 Solo and small-firm criminal defense attorneys face
 massive government discovery productions without access
 to the enterprise eDiscovery tooling available to large
-firms. OpenCase levels the playing field with:
+firms. Gideon levels the playing field with:
 
 - **Semantic search** across entire discovery productions
 - **AI-powered Q&A** with citations to source documents

--- a/scripts/chunk_documents.py
+++ b/scripts/chunk_documents.py
@@ -1,0 +1,139 @@
+"""Submit chunk_document tasks for existing documents.
+
+Reads extracted text from S3 (extracted.json) and submits chunking tasks
+via the API for each document that has been extracted.
+
+Usage:
+    uv run python scripts/chunk_documents.py          # chunk all documents
+    uv run python scripts/chunk_documents.py --limit 3  # chunk first 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import dotenv
+from minio import Minio
+from opencase import Client
+
+
+BASE_URL = "http://127.0.0.1:8000"
+
+
+def get_extracted_text(
+    minio_client: Minio, bucket: str, firm_id: str, matter_id: str, doc_id: str
+) -> str | None:
+    """Fetch extracted.json from S3 and return the text field."""
+    key = f"{firm_id}/{matter_id}/{doc_id}/extracted.json"
+    try:
+        response = minio_client.get_object(bucket, key)
+        data = json.loads(response.read())
+        response.close()
+        response.release_conn()
+        return data.get("text")
+    except Exception as exc:
+        print(f"  No extracted.json: {exc}")
+        return None
+
+
+def s3_prefix(firm_id: str, matter_id: str, doc_id: str) -> str:
+    return f"{firm_id}/{matter_id}/{doc_id}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Submit chunking tasks")
+    parser.add_argument("--limit", type=int, default=0, help="Max documents to chunk (0 = all)")
+    parser.add_argument("--env-file", default=".env", help="Path to .env file")
+    args = parser.parse_args()
+
+    s3_access_key = dotenv.get_key(args.env_file, "OPENCASE_S3_ACCESS_KEY") or "opencase"
+    s3_secret_key = dotenv.get_key(args.env_file, "OPENCASE_S3_SECRET_KEY") or "changeme"
+    s3_bucket = dotenv.get_key(args.env_file, "OPENCASE_S3_BUCKET") or "opencase"
+    admin_email = dotenv.get_key(args.env_file, "OPENCASE_ADMIN_EMAIL")
+    admin_password = dotenv.get_key(args.env_file, "OPENCASE_ADMIN_PASSWORD")
+
+    minio_client = Minio(
+        "localhost:9000",
+        access_key=s3_access_key,
+        secret_key=s3_secret_key,
+        secure=False,
+    )
+
+    with Client(base_url=BASE_URL) as client:
+        client.login(email=admin_email, password=admin_password)
+
+        docs = client.list_documents()
+        if args.limit > 0:
+            docs = docs[: args.limit]
+
+        print(f"Found {len(docs)} document(s) to chunk\n")
+
+        task_ids = []
+        for doc in docs:
+            detail = client.get_document(str(doc.id))
+            print(f"[{doc.filename}] id={doc.id}")
+
+            text = get_extracted_text(
+                minio_client, s3_bucket, str(detail.firm_id), str(doc.matter_id), str(doc.id)
+            )
+            if text is None:
+                print("  Skipped — no extracted text\n")
+                continue
+
+            print(f"  Extracted text: {len(text)} chars")
+
+            prefix = s3_prefix(str(detail.firm_id), str(doc.matter_id), str(doc.id))
+            metadata = {
+                "firm_id": str(detail.firm_id),
+                "matter_id": str(doc.matter_id),
+                "document_id": str(doc.id),
+                "filename": doc.filename,
+                "source": doc.source.value if hasattr(doc.source, "value") else str(doc.source),
+                "classification": (
+                    doc.classification.value
+                    if hasattr(doc.classification, "value")
+                    else str(doc.classification)
+                ),
+            }
+
+            result = client.submit_task(
+                task_name="chunk_document",
+                kwargs={
+                    "document_id": str(doc.id),
+                    "text": text,
+                    "metadata": metadata,
+                    "s3_prefix": prefix,
+                },
+            )
+            print(f"  Task submitted: {result.task_id}\n")
+            task_ids.append((doc.filename, result.task_id))
+
+        if not task_ids:
+            print("No tasks submitted.")
+            client.logout()
+            return
+
+        # Poll for completion
+        print(f"\nWaiting for {len(task_ids)} task(s)...\n")
+        for filename, task_id in task_ids:
+            while True:
+                task = client.get_task(task_id)
+                if task.status in ("completed", "SUCCESS"):
+                    chunk_count = (
+                        task.result.get("chunk_count", "?") if isinstance(task.result, dict) else "?"
+                    )
+                    print(f"  [{filename}] Done — {chunk_count} chunks")
+                    break
+                elif task.status in ("failed", "FAILURE"):
+                    print(f"  [{filename}] FAILED")
+                    break
+                else:
+                    time.sleep(2)
+
+        client.logout()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chunk_documents.py
+++ b/scripts/chunk_documents.py
@@ -14,6 +14,8 @@ import argparse
 import json
 import time
 
+POLL_TIMEOUT_SECONDS = 300
+
 import dotenv
 from minio import Minio
 from opencase import Client
@@ -48,11 +50,18 @@ def main() -> None:
     parser.add_argument("--env-file", default=".env", help="Path to .env file")
     args = parser.parse_args()
 
-    s3_access_key = dotenv.get_key(args.env_file, "OPENCASE_S3_ACCESS_KEY") or "opencase"
-    s3_secret_key = dotenv.get_key(args.env_file, "OPENCASE_S3_SECRET_KEY") or "changeme"
+    s3_access_key = dotenv.get_key(args.env_file, "OPENCASE_S3_ACCESS_KEY")
+    s3_secret_key = dotenv.get_key(args.env_file, "OPENCASE_S3_SECRET_KEY")
     s3_bucket = dotenv.get_key(args.env_file, "OPENCASE_S3_BUCKET") or "opencase"
     admin_email = dotenv.get_key(args.env_file, "OPENCASE_ADMIN_EMAIL")
     admin_password = dotenv.get_key(args.env_file, "OPENCASE_ADMIN_PASSWORD")
+
+    if not s3_access_key:
+        raise SystemExit("OPENCASE_S3_ACCESS_KEY is required")
+    if not s3_secret_key:
+        raise SystemExit("OPENCASE_S3_SECRET_KEY is required")
+    if not admin_email or not admin_password:
+        raise SystemExit("OPENCASE_ADMIN_EMAIL and OPENCASE_ADMIN_PASSWORD are required")
 
     minio_client = Minio(
         "localhost:9000",
@@ -118,7 +127,8 @@ def main() -> None:
         # Poll for completion
         print(f"\nWaiting for {len(task_ids)} task(s)...\n")
         for filename, task_id in task_ids:
-            while True:
+            deadline = time.time() + POLL_TIMEOUT_SECONDS
+            while time.time() < deadline:
                 task = client.get_task(task_id)
                 if task.status in ("completed", "SUCCESS"):
                     chunk_count = (
@@ -131,6 +141,8 @@ def main() -> None:
                     break
                 else:
                     time.sleep(2)
+            else:
+                print(f"  [{filename}] TIMEOUT after {POLL_TIMEOUT_SECONDS}s")
 
         client.logout()
 

--- a/scripts/extract_zips.py
+++ b/scripts/extract_zips.py
@@ -33,6 +33,11 @@ def extract_zips(src_dir: Path, dest_dir: Path) -> None:
             print(f"Extracting {zf_path.name} -> {folder_name}/")
 
             with zipfile.ZipFile(zf_path, "r") as zf:
+                resolved_dest = extract_to.resolve()
+                for member in zf.namelist():
+                    member_path = (extract_to / member).resolve()
+                    if not str(member_path).startswith(str(resolved_dest)):
+                        raise ValueError(f"Attempted path traversal in ZIP: {member}")
                 zf.extractall(extract_to)
 
         # Merge all extracted folders into dest, skipping collisions

--- a/scripts/extract_zips.py
+++ b/scripts/extract_zips.py
@@ -1,0 +1,65 @@
+"""Extract all ZIP files from a source directory into a single destination.
+
+Each ZIP is first extracted into a subfolder named after the ZIP file,
+then all subfolders are merged into the destination directory. Files
+that already exist at the destination path are skipped.
+
+Usage:
+    python scripts/extract_zips.py /path/to/zips /path/to/output
+"""
+
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def extract_zips(src_dir: Path, dest_dir: Path) -> None:
+    zips = sorted(src_dir.glob("*.zip"))
+    if not zips:
+        print(f"No ZIP files found in {src_dir}")
+        return
+
+    print(f"Found {len(zips)} ZIP file(s)")
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        for zf_path in zips:
+            folder_name = zf_path.stem
+            extract_to = tmp_path / folder_name
+            print(f"Extracting {zf_path.name} -> {folder_name}/")
+
+            with zipfile.ZipFile(zf_path, "r") as zf:
+                zf.extractall(extract_to)
+
+        # Merge all extracted folders into dest, skipping collisions
+        skipped = 0
+        copied = 0
+        for folder in sorted(tmp_path.iterdir()):
+            if not folder.is_dir():
+                continue
+            for file in folder.rglob("*"):
+                if not file.is_file():
+                    continue
+                rel = file.relative_to(tmp_path)
+                target = dest_dir / rel
+                if target.exists():
+                    print(f"  SKIP (exists): {rel}")
+                    skipped += 1
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(file, target)
+                copied += 1
+
+    print(f"\nDone. Copied {copied} file(s), skipped {skipped} collision(s).")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: python {sys.argv[0]} <zip_directory> <output_directory>")
+        sys.exit(1)
+
+    extract_zips(Path(sys.argv[1]), Path(sys.argv[2]))

--- a/scripts/query_users.py
+++ b/scripts/query_users.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Authenticate via the SDK and list all users."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from opencase import OpenCaseClient
+
+load_dotenv()
+
+email = os.environ.get("OPENCASE_ADMIN_EMAIL")
+password = os.environ.get("OPENCASE_ADMIN_PASSWORD")
+base_url = os.environ.get("OPENCASE_API_URL", "http://localhost:8000")
+
+if not email or not password:
+    print("Set OPENCASE_ADMIN_EMAIL and OPENCASE_ADMIN_PASSWORD in .env")
+    sys.exit(1)
+
+with OpenCaseClient(base_url=base_url) as client:
+    result = client.login(email=email, password=password)
+
+    if hasattr(result, "mfa_required") and result.mfa_required:
+        print("MFA required — enter TOTP code to continue.")
+        code = input("TOTP code: ")
+        client.verify_mfa(mfa_token=result.mfa_token, totp_code=code)
+
+    users = client.list_users()
+    for user in users:
+        print(f"{user.id}  {user.email}  {user.role}  {user.first_name} {user.last_name}")
+
+    client.logout()

--- a/scripts/query_users.py
+++ b/scripts/query_users.py
@@ -8,28 +8,37 @@ import sys
 
 from dotenv import load_dotenv
 
-from opencase import OpenCaseClient
+from opencase import Client
 
-load_dotenv()
 
-email = os.environ.get("OPENCASE_ADMIN_EMAIL")
-password = os.environ.get("OPENCASE_ADMIN_PASSWORD")
-base_url = os.environ.get("OPENCASE_API_URL", "http://localhost:8000")
+def main() -> None:
+    load_dotenv()
 
-if not email or not password:
-    print("Set OPENCASE_ADMIN_EMAIL and OPENCASE_ADMIN_PASSWORD in .env")
-    sys.exit(1)
+    email = os.environ.get("OPENCASE_ADMIN_EMAIL")
+    password = os.environ.get("OPENCASE_ADMIN_PASSWORD")
+    base_url = os.environ.get("OPENCASE_API_URL", "http://localhost:8000")
 
-with OpenCaseClient(base_url=base_url) as client:
-    result = client.login(email=email, password=password)
+    if not email or not password:
+        print("Set OPENCASE_ADMIN_EMAIL and OPENCASE_ADMIN_PASSWORD in .env")
+        sys.exit(1)
 
-    if hasattr(result, "mfa_required") and result.mfa_required:
-        print("MFA required — enter TOTP code to continue.")
-        code = input("TOTP code: ")
-        client.verify_mfa(mfa_token=result.mfa_token, totp_code=code)
+    with Client(base_url=base_url) as client:
+        result = client.login(email=email, password=password)
 
-    users = client.list_users()
-    for user in users:
-        print(f"{user.id}  {user.email}  {user.role}  {user.first_name} {user.last_name}")
+        if getattr(result, "mfa_required", False):
+            print("MFA required — enter TOTP code to continue.")
+            code = input("TOTP code: ")
+            mfa_token = getattr(result, "mfa_token", None)
+            if not mfa_token:
+                sys.exit("MFA required but no mfa_token in login response")
+            client.verify_mfa(mfa_token=mfa_token, totp_code=code)
 
-    client.logout()
+        users = client.list_users()
+        for user in users:
+            print(f"{user.id}  {user.email}  {user.role}  {user.first_name} {user.last_name}")
+
+        client.logout()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Rename project from OpenCase to **Gideon** (after *Gideon v. Wainwright*, 1963) in CLAUDE.md and README.md
- Add release naming convention — major versions named after famous jurists, starting with v1 "Ginsburg"
- Add utility scripts: `extract_zips.py` (merge ZIP contents into single directory), `chunk_documents.py`, `query_users.py`

## Test plan
- [ ] Verify CLAUDE.md and README.md render correctly with new project name
- [ ] Run `python scripts/extract_zips.py` with test ZIPs to confirm extraction and collision skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)