### PR TITLE
feat: chat schema — chat_sessions, chat_queries, chat_feedback (Feature 7.1)

### DIFF
--- a/backend/alembic/versions/0006_chat_schema.py
+++ b/backend/alembic/versions/0006_chat_schema.py
@@ -108,6 +108,7 @@ def upgrade() -> None:
         ),
     )
     op.create_index("ix_chat_queries_session_id", "chat_queries", ["session_id"])
+    op.create_index("ix_chat_queries_user_id", "chat_queries", ["user_id"])
 
     # --- chat_feedback ---
     op.create_table(
@@ -137,8 +138,8 @@ def upgrade() -> None:
         ),
         sa.UniqueConstraint("query_id", name="uq_chat_feedback_query_id"),
         sa.CheckConstraint("rating IN (-1, 1)", name="ck_chat_feedback_rating"),
+        # uq_chat_feedback_query_id creates the implicit index on query_id
     )
-    op.create_index("ix_chat_feedback_query_id", "chat_feedback", ["query_id"])
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0006_chat_schema.py
+++ b/backend/alembic/versions/0006_chat_schema.py
@@ -1,0 +1,145 @@
+"""Replace prompts table with chat_sessions, chat_queries, and chat_feedback.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-10 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NOW = sa.text("now()")
+_FALSE = sa.text("false")
+
+
+def upgrade() -> None:
+    # --- drop the prompts stub (superseded by chat tables) ---
+    op.drop_index("ix_prompts_matter_id", table_name="prompts")
+    op.drop_index("ix_prompts_firm_id", table_name="prompts")
+    op.drop_table("prompts")
+
+    # --- chat_sessions ---
+    op.create_table(
+        "chat_sessions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("firm_id", sa.Uuid(), nullable=False),
+        sa.Column("matter_id", sa.Uuid(), nullable=False),
+        sa.Column("created_by", sa.Uuid(), nullable=False),
+        sa.Column("title", sa.String(255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=_NOW,
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=_NOW,
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_chat_sessions"),
+        sa.ForeignKeyConstraint(
+            ["firm_id"],
+            ["firms.id"],
+            name="fk_chat_sessions_firm_id_firms",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["matter_id"],
+            ["matters.id"],
+            name="fk_chat_sessions_matter_id_matters",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by"],
+            ["users.id"],
+            name="fk_chat_sessions_created_by_users",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index("ix_chat_sessions_firm_id", "chat_sessions", ["firm_id"])
+    op.create_index("ix_chat_sessions_matter_id", "chat_sessions", ["matter_id"])
+
+    # --- chat_queries ---
+    op.create_table(
+        "chat_queries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("session_id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("query", sa.Text(), nullable=False),
+        sa.Column("response", sa.Text(), nullable=True),
+        sa.Column("model_name", sa.String(100), nullable=True),
+        sa.Column(
+            "retrieval_context",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("tokens_used", sa.Integer(), nullable=True),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=_NOW,
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_chat_queries"),
+        sa.ForeignKeyConstraint(
+            ["session_id"],
+            ["chat_sessions.id"],
+            name="fk_chat_queries_session_id_chat_sessions",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_chat_queries_user_id_users",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index("ix_chat_queries_session_id", "chat_queries", ["session_id"])
+
+    # --- chat_feedback ---
+    op.create_table(
+        "chat_feedback",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("query_id", sa.Uuid(), nullable=False),
+        sa.Column("rating", sa.SmallInteger(), nullable=False),
+        sa.Column(
+            "flag_bad_citation",
+            sa.Boolean(),
+            nullable=False,
+            server_default=_FALSE,
+        ),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=_NOW,
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_chat_feedback"),
+        sa.ForeignKeyConstraint(
+            ["query_id"],
+            ["chat_queries.id"],
+            name="fk_chat_feedback_query_id_chat_queries",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("query_id", name="uq_chat_feedback_query_id"),
+        sa.CheckConstraint("rating IN (-1, 1)", name="ck_chat_feedback_rating"),
+    )
+    op.create_index("ix_chat_feedback_query_id", "chat_feedback", ["query_id"])
+
+
+def downgrade() -> None:
+    pass  # fix-forward — never roll back schema changes

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -1,20 +1,24 @@
 """DB models — import all models here so Alembic can discover them via Base.metadata."""
 
+from app.db.models.chat_feedback import ChatFeedback
+from app.db.models.chat_query import ChatQuery
+from app.db.models.chat_session import ChatSession
 from app.db.models.document import Document
 from app.db.models.firm import Firm
 from app.db.models.matter import Matter
 from app.db.models.matter_access import MatterAccess
-from app.db.models.prompt import Prompt
 from app.db.models.refresh_token import RefreshToken
 from app.db.models.task_submission import TaskSubmission
 from app.db.models.user import User
 
 __all__ = [
+    "ChatFeedback",
+    "ChatQuery",
+    "ChatSession",
     "Document",
     "Firm",
     "Matter",
     "MatterAccess",
-    "Prompt",
     "RefreshToken",
     "TaskSubmission",
     "User",

--- a/backend/app/db/models/chat_feedback.py
+++ b/backend/app/db/models/chat_feedback.py
@@ -28,8 +28,9 @@ class ChatFeedback(Base):
     __tablename__ = "chat_feedback"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    # no index=True — UniqueConstraint below creates the implicit index in PG
     query_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("chat_queries.id", ondelete="CASCADE"), nullable=False, index=True
+        ForeignKey("chat_queries.id", ondelete="CASCADE"), nullable=False
     )
     rating: Mapped[int] = mapped_column(SmallInteger, nullable=False)
     flag_bad_citation: Mapped[bool] = mapped_column(
@@ -41,7 +42,7 @@ class ChatFeedback(Base):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
-    query: Mapped[ChatQuery] = relationship(back_populates="feedback")
+    chat_query: Mapped[ChatQuery] = relationship(back_populates="feedback")
 
     __table_args__ = (
         UniqueConstraint("query_id", name="uq_chat_feedback_query_id"),

--- a/backend/app/db/models/chat_feedback.py
+++ b/backend/app/db/models/chat_feedback.py
@@ -1,0 +1,49 @@
+"""ChatFeedback model — one user rating per chat query turn."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+if TYPE_CHECKING:
+    from app.db.models.chat_query import ChatQuery
+
+
+class ChatFeedback(Base):
+    __tablename__ = "chat_feedback"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    query_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("chat_queries.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    rating: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    flag_bad_citation: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    comment: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    query: Mapped[ChatQuery] = relationship(back_populates="feedback")
+
+    __table_args__ = (
+        UniqueConstraint("query_id", name="uq_chat_feedback_query_id"),
+        CheckConstraint("rating IN (-1, 1)", name="ck_chat_feedback_rating"),
+    )

--- a/backend/app/db/models/chat_query.py
+++ b/backend/app/db/models/chat_query.py
@@ -1,0 +1,48 @@
+"""ChatQuery model — one row per query/response turn within a chat session."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+if TYPE_CHECKING:
+    from app.db.models.chat_feedback import ChatFeedback
+    from app.db.models.chat_session import ChatSession
+    from app.db.models.user import User
+
+
+class ChatQuery(Base):
+    __tablename__ = "chat_queries"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("chat_sessions.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    query: Mapped[str] = mapped_column(Text, nullable=False)
+    response: Mapped[str | None] = mapped_column(Text, nullable=True)
+    model_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    retrieval_context: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    tokens_used: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    session: Mapped[ChatSession] = relationship(back_populates="queries")
+    user: Mapped[User] = relationship()
+    feedback: Mapped[list[ChatFeedback]] = relationship(
+        back_populates="query", passive_deletes=True
+    )

--- a/backend/app/db/models/chat_query.py
+++ b/backend/app/db/models/chat_query.py
@@ -26,11 +26,14 @@ class ChatQuery(Base):
         ForeignKey("chat_sessions.id", ondelete="CASCADE"), nullable=False, index=True
     )
     user_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     query: Mapped[str] = mapped_column(Text, nullable=False)
     response: Mapped[str | None] = mapped_column(Text, nullable=True)
     model_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    # shape: {"chunks": [{"document_id": "...", "chunk_index": 0,
+    #                      "text": "...", "score": 0.87}]}
+    # exact structure finalized in Feature 7.5 (citation assembly)
     retrieval_context: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB, nullable=True
     )
@@ -43,6 +46,6 @@ class ChatQuery(Base):
 
     session: Mapped[ChatSession] = relationship(back_populates="queries")
     user: Mapped[User] = relationship()
-    feedback: Mapped[list[ChatFeedback]] = relationship(
-        back_populates="query", passive_deletes=True
+    feedback: Mapped[ChatFeedback | None] = relationship(
+        back_populates="chat_query", passive_deletes=True, uselist=False
     )

--- a/backend/app/db/models/chat_session.py
+++ b/backend/app/db/models/chat_session.py
@@ -1,4 +1,4 @@
-"""Prompt model — one row per user query submitted to the AI chatbot."""
+"""ChatSession model — one row per named conversation thread within a matter."""
 
 from __future__ import annotations
 
@@ -6,19 +6,20 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy import DateTime, ForeignKey, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base
 
 if TYPE_CHECKING:
+    from app.db.models.chat_query import ChatQuery
     from app.db.models.firm import Firm
     from app.db.models.matter import Matter
     from app.db.models.user import User
 
 
-class Prompt(Base):
-    __tablename__ = "prompts"
+class ChatSession(Base):
+    __tablename__ = "chat_sessions"
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     firm_id: Mapped[uuid.UUID] = mapped_column(
@@ -27,11 +28,10 @@ class Prompt(Base):
     matter_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    query: Mapped[str] = mapped_column(Text, nullable=False)
-    response: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
+    title: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -46,3 +46,6 @@ class Prompt(Base):
     firm: Mapped[Firm] = relationship()
     matter: Mapped[Matter] = relationship()
     creator: Mapped[User] = relationship()
+    queries: Mapped[list[ChatQuery]] = relationship(
+        back_populates="session", passive_deletes=True
+    )

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,10 +1,10 @@
 # OpenCase — Entity Relationship Diagram
 
-Covers tables through Feature 3.2. Tables from later features
+Covers tables through Feature 7.1. Tables from later features
 (audit_log, witnesses, disclosure_checklist, etc.) will be added
 as each feature lands.
 
-## Core + Worker Queue Schema
+## Core Schema
 
 ```mermaid
 erDiagram
@@ -62,6 +62,7 @@ erDiagram
         int size_bytes
         enum source "government_production | defense | court | work_product"
         enum classification "brady | giglio | jencks | rule16 | work_product | inculpatory | unclassified"
+        enum ingestion_status "pending | extracting | chunking | embedding | indexed | failed"
         string bates_number "nullable"
         bool legal_hold
         uuid uploaded_by FK
@@ -69,17 +70,21 @@ erDiagram
         timestamptz updated_at
     }
 
-    prompts {
-        uuid id PK
-        uuid firm_id FK
-        uuid matter_id FK
-        text query
-        text response "nullable — stub for now"
-        uuid created_by FK
-        timestamptz created_at
-        timestamptz updated_at
-    }
+    firms ||--o{ users : "has"
+    firms ||--o{ matters : "owns"
+    firms ||--o{ documents : "scoped to"
+    users ||--o{ matter_access : "access controlled via"
+    matters ||--o{ matter_access : "access controlled via"
+    matters ||--o{ documents : "contains"
+    users ||--o{ documents : "uploaded by"
+```
 
+## Worker Queue Schema
+
+`firm_id` and `user_id` are FKs to the Core Schema `firms` and `users` tables.
+
+```mermaid
+erDiagram
     task_submissions {
         string id PK "Celery task ID"
         uuid firm_id FK
@@ -90,20 +95,52 @@ erDiagram
         string status "TaskState enum — pending | started | success | failure | revoked | retry"
         timestamptz submitted_at
     }
-
-    firms ||--o{ users : "has"
-    firms ||--o{ matters : "owns"
-    firms ||--o{ documents : "scoped to"
-    firms ||--o{ prompts : "scoped to"
-    users ||--o{ matter_access : "access controlled via"
-    matters ||--o{ matter_access : "access controlled via"
-    matters ||--o{ documents : "contains"
-    matters ||--o{ prompts : "queried within"
-    users ||--o{ documents : "uploaded by"
-    users ||--o{ prompts : "created by"
-    firms ||--o{ task_submissions : "scoped to"
-    users ||--o{ task_submissions : "submitted by"
 ```
+
+## Chat Schema
+
+```mermaid
+erDiagram
+    chat_sessions {
+        uuid id PK
+        uuid firm_id FK
+        uuid matter_id FK
+        uuid created_by FK
+        string title "nullable — auto-generated or user-set"
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    chat_queries {
+        uuid id PK
+        uuid session_id FK
+        uuid user_id FK "who submitted this query"
+        text query
+        text response "nullable — null while awaiting LLM"
+        string model_name "nullable — Ollama model identifier"
+        jsonb retrieval_context "nullable — retrieved chunks for citations"
+        int tokens_used "nullable"
+        int latency_ms "nullable"
+        timestamptz created_at
+    }
+
+    chat_feedback {
+        uuid id PK
+        uuid query_id FK
+        smallint rating "+1 thumbs up | -1 thumbs down"
+        bool flag_bad_citation
+        text comment "nullable — free text for prompt tuning"
+        timestamptz created_at
+    }
+
+    chat_sessions ||--o{ chat_queries : "contains"
+    chat_queries ||--o{ chat_feedback : "rated by"
+```
+
+`firm_id` and `matter_id` on `chat_sessions` are FKs to the Core Schema.
+`firm_id` and `matter_id` are not stored on `chat_queries` — derivable via
+`JOIN chat_sessions`. `user_id` on `chat_feedback` is not stored — derivable
+via `JOIN chat_queries`.
 
 ## Key Constraints
 
@@ -119,13 +156,18 @@ erDiagram
 | `documents` | `fk_documents_firm_id_firms` | Cascades on firm delete |
 | `documents` | `fk_documents_matter_id_matters` | Cascades on matter delete |
 | `documents` | `fk_documents_uploaded_by_users` | Cascades on user delete |
-| `prompts` | `fk_prompts_firm_id_firms` | Cascades on firm delete |
-| `prompts` | `fk_prompts_matter_id_matters` | Cascades on matter delete |
-| `prompts` | `fk_prompts_created_by_users` | Cascades on user delete |
 | `task_submissions` | `fk_task_submissions_firm_id_firms` | Cascades on firm delete |
 | `task_submissions` | `fk_task_submissions_user_id_users` | Cascades on user delete |
 | `task_submissions` | `ix_task_submissions_firm_id` | Index on `firm_id` for firm-scoped queries |
 | `task_submissions` | `ix_task_submissions_task_name` | Index on `task_name` for filtering |
+| `chat_sessions` | `fk_chat_sessions_firm_id_firms` | Cascades on firm delete |
+| `chat_sessions` | `fk_chat_sessions_matter_id_matters` | Cascades on matter delete |
+| `chat_sessions` | `fk_chat_sessions_created_by_users` | Cascades on user delete |
+| `chat_queries` | `fk_chat_queries_session_id_chat_sessions` | Cascades on session delete |
+| `chat_queries` | `fk_chat_queries_user_id_users` | Cascades on user delete |
+| `chat_feedback` | `uq_chat_feedback_query_id` | One feedback row per query |
+| `chat_feedback` | `ck_chat_feedback_rating` | Rating must be -1 or +1 |
+| `chat_feedback` | `fk_chat_feedback_query_id_chat_queries` | Cascades on query delete |
 
 ## Notes
 
@@ -147,3 +189,9 @@ erDiagram
   primary key is assigned by Celery at submission time.
 - `task_submissions.status` is denormalized from the Celery result backend and
   updated on read via `GET /tasks/{task_id}`.
+- `chat_queries.retrieval_context` is JSONB with a suggested shape:
+  `{"chunks": [{"document_id": "...", "chunk_index": 0, "text": "...",`
+  `"score": 0.87}]}`. The exact structure is finalized in Feature 7.5
+  (citation assembly).
+- `chat_queries.response` is nullable — null while the LLM is generating a response.
+  The row is inserted at query time and updated when inference completes.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -64,7 +64,7 @@
 | 6.8 | Cloud ingestion Beat schedule (15-min polling interval) | Pending |
 | 6.10 | Observability (ingestion spans/metrics) | Pending |
 | **7.0** | **Chatbot / Q&A** | **Pending** |
-| 7.1 | DB models + migration (chat_queries, conversation_history, feedback tables) | Pending |
+| 7.1 | DB models + migration (chat_sessions, chat_queries, chat_feedback tables) | Done |
 | 7.2 | LLM inference model setup (Ollama model pull — Llama 3 8B / Mistral 7B, health check) | Pending |
 | 7.3 | Matter-scoped RAG query API endpoint (LangChain + Qdrant retrieval + Ollama inference, wired up via FastAPI) | Pending |
 | 7.4 | Minimal chat interface (CLI command or lightweight web UI for testing/demo) | Pending |

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -446,6 +446,32 @@ mixed types (strings, lists, numbers) in its metadata response.
 
 ---
 
+## 2026-04-10 — Chat schema
+
+*~1 hour (single session)*
+
+**Chat schema (Feature 7.1):** Replaced the `prompts` stub with three
+purpose-built chat tables. `chat_sessions` models named conversation threads
+within a matter. `chat_queries` records individual query/response turns with
+a JSONB `retrieval_context` column for citation explainability and nullable
+`response` for future streaming support. `chat_feedback` captures per-query
+thumbs-up/thumbs-down ratings with a bad-citation flag and free-text comment
+for future RAG/prompt tuning analysis. The schema is fully normalized —
+`firm_id`/`matter_id` are not denormalized onto `chat_queries` (derivable
+via join to `chat_sessions`), and `user_id` is not denormalized onto
+`chat_feedback` (derivable via join to `chat_queries`).
+
+Alembic migration `0006_chat_schema` drops `prompts` and creates the three
+new tables in dependency order. The `prompt.py` model file is deleted;
+`__init__.py` exports the three new model classes. Split `ERD.md` into three
+separate diagrams: Core Schema, Worker Queue Schema, and Chat Schema. Also
+corrected the ERD to include `ingestion_status` on `documents` (added in
+migration `0005` but missing from the diagram).
+
+**Commits:** Feature 7.1
+
+---
+
 ## Running Total
 
 | Date | Est. Hours |
@@ -463,7 +489,8 @@ mixed types (strings, lists, numbers) in its metadata response.
 | Mar 27 | ~3 |
 | Mar 28 | ~8 |
 | Mar 30 | ~3 |
-| **Total to date** | **~59 ± 7 hours** |
+| Apr 10 | ~1 |
+| **Total to date** | **~60 ± 7 hours** |
 
 **Estimated remaining (critical path to MVP — Features 5–9):**
 


### PR DESCRIPTION
## Summary

- Replaces the `prompts` stub table with three purpose-built chat tables: `chat_sessions` (conversation threads per matter), `chat_queries` (individual RAG query/response turns with JSONB `retrieval_context` for citations), and `chat_feedback` (thumbs-up/down ratings + bad-citation flag for future prompt tuning)
- Alembic migration `0006` drops `prompts` and creates the three tables in dependency order
- `ERD.md` split into three separate Mermaid diagrams: Core Schema, Worker Queue Schema, Chat Schema

## Schema decisions

- **Normalized**: `firm_id`/`matter_id` not stored on `chat_queries` (derivable via `JOIN chat_sessions`); `user_id` not stored on `chat_feedback` (derivable via `JOIN chat_queries`)
- **Cascade chain**: `firms → chat_sessions → chat_queries → chat_feedback` — firm deletion cascades cleanly through all tables
- **`chat_feedback` constraints**: `uq_chat_feedback_query_id` (one rating per query) + `ck_chat_feedback_rating` (CHECK `rating IN (-1, 1)`)
- **`retrieval_context`**: JSONB column on `chat_queries` for storing retrieved chunks; enables future GIN indexing for citation search

## Test plan

- [ ] Run `docker compose up db-migrate` — migration `0006` applies cleanly, `prompts` table gone, three new tables present
- [ ] `python -c "from app.db.models import ChatSession, ChatQuery, ChatFeedback"` — imports succeed
- [ ] Existing integration tests pass (no API routes reference `Prompt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)