### PR TITLE
feat: matter-scoped RAG query endpoint (Feature 7.3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -232,6 +232,11 @@ GIDEON_EMBEDDING_PROVIDER="ollama"
 GIDEON_EMBEDDING_MODEL="nomic-embed-text"
 # Ollama API base URL (Docker service name inside compose network)
 GIDEON_EMBEDDING_BASE_URL="http://ollama:11434"
+# Additional models to pre-pull at startup (comma-separated).
+# All models are stored in the ollama-models Docker volume and survive
+# container restarts. Add any models you want available for eval here.
+# Example: GIDEON_ADDITIONAL_MODELS=mistral,qwen3:8b,phi4
+GIDEON_ADDITIONAL_MODELS=""
 # Output vector dimensions (must match the model — 768 for nomic-embed-text)
 GIDEON_EMBEDDING_DIMENSIONS="768"
 # Number of chunks per embedding batch request

--- a/backend/SYSTEM_PROMPT.md
+++ b/backend/SYSTEM_PROMPT.md
@@ -6,8 +6,10 @@ Your role is to help attorneys and their staff review case documents and answer 
 
 1. Answer only from the documents retrieved for this matter. If the answer is not in the provided context, say so clearly: "I did not find information about this in the case documents."
 2. Always cite the source document, page number, and Bates number (if available) for every factual claim.
-3. Never reveal attorney work product, internal notes, or privileged communications unless the user has explicit permission.
-4. If a question involves Jencks Act material and the witness has not yet testified, state that the material is not yet available.
+3. Never reveal attorney work product, internal notes, or privileged
+   communications unless the user has explicit permission.
+4. If a question involves Jencks Act material and the witness has not
+   yet testified, state that the material is not yet available.
 5. Do not provide legal advice. You assist with document review and factual questions only.
 6. Use plain, precise language. Avoid legalese unless quoting a document directly.
 

--- a/backend/app/api/chats.py
+++ b/backend/app/api/chats.py
@@ -1,32 +1,29 @@
-"""Chats router — stub endpoints for AI chatbot Q&A sessions."""
+"""Chats router — matter-scoped RAG chatbot Q&A sessions."""
 
 from __future__ import annotations
 
-import uuid
-from datetime import UTC, datetime
+import json
+from collections.abc import AsyncGenerator
 
 from fastapi import APIRouter, Depends, status
+from fastapi.responses import StreamingResponse
 from opentelemetry import trace
 from shared.models.chat import (
     ChatQueryResponse,
     ChatSessionResponse,
     SubmitQueryRequest,
 )
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
-from app.core.config import settings
 from app.core.metrics import chat_queries_created
+from app.db import get_db
 from app.db.models.user import User
+from app.rag.pipeline import run_query, stream_query
 
 tracer = trace.get_tracer(__name__)
 
 router = APIRouter(prefix="/chats", tags=["chats"])
-
-_STUB_RESPONSE = (
-    "This is a stub response. RAG integration is not yet implemented. "
-    "In a future release this endpoint will perform a matter-scoped vector search "
-    "and return a cited answer from your case documents."
-)
 
 
 # ---------------------------------------------------------------------------
@@ -42,29 +39,76 @@ _STUB_RESPONSE = (
 async def submit_query(
     body: SubmitQueryRequest,
     user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
 ) -> ChatQueryResponse:
-    """Stub — accepts a query and returns a canned response.
+    """Run a matter-scoped RAG query and return the full response.
 
-    Future: will create or continue a ChatSession, run a matter-scoped RAG
-    query against Qdrant, call Ollama for inference, and return a cited answer.
+    Retrieves the top-K most semantically relevant chunks from Qdrant
+    (permission-filtered via ``build_qdrant_filter``), assembles a prompt
+    with the SYSTEM_PROMPT and retrieved context, calls Ollama for inference,
+    and persists the query + response to the database.
     """
     with tracer.start_as_current_span(
         "chats.submit_query",
         attributes={"user.id": str(user.id), "matter.id": str(body.matter_id)},
     ):
-        now = datetime.now(UTC)
-        session_id = body.session_id or uuid.uuid4()
-        query_id = uuid.uuid4()
+        session, record = await run_query(
+            body.query, user, body.matter_id, body.session_id, db
+        )
         chat_queries_created.add(1)
         return ChatQueryResponse(
-            id=query_id,
-            session_id=session_id,
-            matter_id=body.matter_id,
-            query=body.query,
-            response=_STUB_RESPONSE,
-            model_name=settings.chatbot.model,
-            created_at=now,
+            id=record.id,
+            session_id=session.id,
+            matter_id=session.matter_id,
+            query=record.query,
+            response=record.response,
+            model_name=record.model_name,
+            created_at=record.created_at,
         )
+
+
+# ---------------------------------------------------------------------------
+# POST /chats/stream
+# ---------------------------------------------------------------------------
+
+
+@router.post("/stream")
+async def submit_query_stream(
+    body: SubmitQueryRequest,
+    user: User = Depends(get_current_user),  # noqa: B008
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> StreamingResponse:
+    """Stream a matter-scoped RAG response as Server-Sent Events.
+
+    Performs the same retrieval + prompt assembly as ``submit_query``,
+    but yields individual tokens as ``data: {"token": "..."}`` SSE lines.
+    Terminates with ``data: [DONE]``, or ``data: {"error": "..."}``
+    followed by ``data: [DONE]`` if inference fails mid-stream.
+
+    The database record is saved after the stream is fully consumed
+    (the db session remains open until the generator is exhausted).
+    The OpenTelemetry span covers the full stream lifetime, not just
+    the setup, so latency and errors are correctly attributed.
+    """
+    span = tracer.start_span(
+        "chats.submit_query_stream",
+        attributes={"user.id": str(user.id), "matter.id": str(body.matter_id)},
+    )
+    gen = stream_query(body.query, user, body.matter_id, body.session_id, db)
+
+    async def _sse() -> AsyncGenerator[bytes, None]:
+        try:
+            async for token in gen:
+                yield f"data: {json.dumps({'token': token})}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+        except Exception as exc:
+            span.record_exception(exc)
+            yield f"data: {json.dumps({'error': str(exc)})}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+        finally:
+            span.end()
+
+    return StreamingResponse(_sse(), media_type="text/event-stream")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/chats.py
+++ b/backend/app/api/chats.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncGenerator
 
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import StreamingResponse
+from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.trace import StatusCode
 from shared.models.chat import (
     ChatQueryResponse,
     ChatSessionResponse,
@@ -21,6 +24,7 @@ from app.db import get_db
 from app.db.models.user import User
 from app.rag.pipeline import run_query, stream_query
 
+logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
 router = APIRouter(prefix="/chats", tags=["chats"])
@@ -94,6 +98,11 @@ async def submit_query_stream(
         "chats.submit_query_stream",
         attributes={"user.id": str(user.id), "matter.id": str(body.matter_id)},
     )
+    # Install the span as the current context so child spans created inside
+    # stream_query attach to the correct parent.
+    ctx = trace.set_span_in_context(span)
+    attachment = otel_context.attach(ctx)
+
     gen = stream_query(body.query, user, body.matter_id, body.session_id, db)
 
     async def _sse() -> AsyncGenerator[bytes, None]:
@@ -103,9 +112,18 @@ async def submit_query_stream(
             yield b"data: [DONE]\n\n"
         except Exception as exc:
             span.record_exception(exc)
+            span.set_status(StatusCode.ERROR, str(exc))
+            logger.error(
+                "Stream error for user %s matter %s: %s",
+                user.id,
+                body.matter_id,
+                exc,
+                exc_info=True,
+            )
             yield f"data: {json.dumps({'error': str(exc)})}\n\n".encode()
             yield b"data: [DONE]\n\n"
         finally:
+            otel_context.detach(attachment)
             span.end()
 
     return StreamingResponse(_sse(), media_type="text/event-stream")

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -261,3 +261,19 @@ vectorstore_delete_duration_seconds = meter.create_histogram(
     description="Vector delete latency in seconds",
     unit="s",
 )
+
+vectorstore_search_completed = meter.create_counter(
+    "gideon.vectorstore.search.completed",
+    description="Successful vector similarity search operations",  # attrs: collection
+)
+
+vectorstore_search_failed = meter.create_counter(
+    "gideon.vectorstore.search.failed",
+    description="Failed vector similarity search operations",  # attrs: collection
+)
+
+vectorstore_search_duration_seconds = meter.create_histogram(
+    "gideon.vectorstore.search.duration_seconds",
+    description="Vector search latency in seconds",
+    unit="s",
+)

--- a/backend/app/rag/pipeline.py
+++ b/backend/app/rag/pipeline.py
@@ -18,7 +18,6 @@ import logging
 import time
 import uuid
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING
 
 import httpx
 from fastapi import HTTPException, status
@@ -36,9 +35,6 @@ from app.db.models.chat_query import ChatQuery
 from app.db.models.chat_session import ChatSession
 from app.db.models.user import User
 from app.vectorstore import get_vectorstore_service
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -461,20 +457,28 @@ async def stream_query(
             )
 
             full_response: list[str] = []
-            async for chunk in llm.astream(messages):
-                token = str(chunk.content)
-                full_response.append(token)
-                yield token
+            stream_error: BaseException | None = None
+            try:
+                async for chunk in llm.astream(messages):
+                    token = str(chunk.content)
+                    full_response.append(token)
+                    yield token
+            except Exception as exc:
+                stream_error = exc
 
             latency_ms = int((time.monotonic() - start) * 1000)
             span.set_attribute("rag.latency_ms", latency_ms)
             span.set_attribute("rag.chunk_count", len(chunks))
 
-            # 7. Persist — db session is still alive at this point
+            # 7. Always persist — even a partial response is an audit record.
+            #    db session remains open until StreamingResponse is consumed.
             session = await _get_or_create_session(db, user, matter_id, session_id)
             await _save_query(
                 db, session, user, query, "".join(full_response), chunks, latency_ms
             )
+
+            if stream_error is not None:
+                raise stream_error
 
         except Exception as exc:
             span.set_status(StatusCode.ERROR, str(exc))

--- a/backend/app/rag/pipeline.py
+++ b/backend/app/rag/pipeline.py
@@ -1,0 +1,494 @@
+"""RAG pipeline — embed query, retrieve chunks, assemble prompt, run inference.
+
+This module is the core of Feature 7.3. It wires together:
+  - Qdrant similarity search (always gated by build_qdrant_filter)
+  - Ollama embedding for query vectorisation
+  - Prompt assembly (SYSTEM_PROMPT + retrieved context + user query)
+  - Ollama inference via LangChain ChatOllama (non-streaming and streaming)
+  - ChatSession / ChatQuery persistence
+
+build_qdrant_filter() is called first in every entrypoint and is never
+bypassed. The PermissionFilter it returns is converted to a
+qdrant_client.models.Filter before any search is issued.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+import httpx
+from fastapi import HTTPException, status
+from langchain_ollama import ChatOllama
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode
+from qdrant_client import models
+from qdrant_client.models import FieldCondition, MatchAny, MatchValue
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.permissions import PermissionFilter, build_qdrant_filter
+from app.db.models.chat_query import ChatQuery
+from app.db.models.chat_session import ChatSession
+from app.db.models.user import User
+from app.vectorstore import get_vectorstore_service
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Query embedding
+# ---------------------------------------------------------------------------
+
+
+async def embed_query(text: str) -> list[float]:
+    """Embed a single query string via Ollama /api/embed.
+
+    Uses the same model and base_url as ``EmbeddingService`` (both read from
+    ``settings.embedding``) but operates on a single string without the
+    chunk-dict overhead of the ingestion path.
+
+    Args:
+        text: The user's natural-language query.
+
+    Returns:
+        768-dimensional embedding vector.
+
+    Raises:
+        httpx.HTTPStatusError: If Ollama returns a non-2xx response.
+        httpx.ConnectError: If Ollama is unreachable.
+    """
+    async with httpx.AsyncClient(
+        base_url=settings.embedding.base_url,
+        timeout=settings.embedding.request_timeout,
+    ) as client:
+        response = await client.post(
+            "/api/embed",
+            json={"model": settings.embedding.model, "input": [text]},
+        )
+        response.raise_for_status()
+        embeddings: list[list[float]] = response.json()["embeddings"]
+        return embeddings[0]
+
+
+# ---------------------------------------------------------------------------
+# PermissionFilter → qdrant_client.models.Filter
+# ---------------------------------------------------------------------------
+
+
+def _to_qdrant_filter(pf: PermissionFilter) -> models.Filter:
+    """Convert a PermissionFilter to a qdrant_client Filter.
+
+    ``matter_ids`` always includes the requested matter plus
+    ``GLOBAL_KNOWLEDGE_MATTER_ID`` (set by ``build_qdrant_filter``).
+    ``excluded_classifications`` is empty for admin, contains ``jencks``
+    for attorney/paralegal, and ``jencks`` + ``work_product`` for investigator.
+
+    Args:
+        pf: Qdrant-agnostic permission filter from ``build_qdrant_filter()``.
+
+    Returns:
+        A ``qdrant_client.models.Filter`` ready to pass to ``client.search()``.
+    """
+    must = [
+        FieldCondition(key="firm_id", match=MatchValue(value=str(pf.firm_id))),
+        FieldCondition(
+            key="matter_id",
+            match=MatchAny(any=[str(m) for m in pf.matter_ids]),
+        ),
+    ]
+    must_not: list[FieldCondition] = []
+    if pf.excluded_classifications:
+        must_not = [
+            FieldCondition(
+                key="classification",
+                match=MatchAny(any=list(pf.excluded_classifications)),
+            )
+        ]
+    return models.Filter(must=must, must_not=must_not)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Context block formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_context(chunks: list[models.ScoredPoint]) -> str:
+    """Format retrieved chunks into a numbered context block for the prompt.
+
+    Each chunk is rendered as a citation header followed by its text.
+    Page number and Bates number are omitted when not present.
+
+    Args:
+        chunks: Scored points returned by Qdrant search, with payload.
+
+    Returns:
+        Multi-line string ready to embed in the user message.
+    """
+    if not chunks:
+        return "No relevant documents were found for this query."
+
+    parts: list[str] = []
+    for i, point in enumerate(chunks, 1):
+        p = point.payload or {}
+        doc_id = str(p.get("document_id", ""))[:8]
+        page = p.get("page_number")
+        bates = p.get("bates_number")
+        text = str(p.get("text", ""))
+
+        header_parts = [f"Source {i}", f"Doc: {doc_id}"]
+        if page is not None:
+            header_parts.append(f"Page: {page}")
+        if bates:
+            header_parts.append(f"Bates: {bates}")
+
+        parts.append(f"[{' | '.join(header_parts)}]\n{text}")
+
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly
+# ---------------------------------------------------------------------------
+
+
+def build_messages(
+    system_prompt: str,
+    query: str,
+    chunks: list[models.ScoredPoint],
+) -> list[dict[str, str]]:
+    """Assemble the system + user messages for Ollama chat inference.
+
+    The user message embeds the retrieved context block above the question
+    so the model can ground its answer in the retrieved documents.
+
+    Args:
+        system_prompt: Loaded from ``settings.chatbot.system_prompt``
+            (sourced from SYSTEM_PROMPT.md or the built-in default).
+        query: The user's natural-language question.
+        chunks: Retrieved Qdrant points with text payload.
+
+    Returns:
+        Two-element list: [{role: system, ...}, {role: user, ...}].
+    """
+    context = _format_context(chunks)
+    return [
+        {"role": "system", "content": system_prompt},
+        {
+            "role": "user",
+            "content": (
+                f"Context from case documents:\n\n{context}\n\nQuestion: {query}"
+            ),
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Session + query persistence
+# ---------------------------------------------------------------------------
+
+
+async def _get_or_create_session(
+    db: AsyncSession,
+    user: User,
+    matter_id: uuid.UUID,
+    session_id: uuid.UUID | None,
+) -> ChatSession:
+    """Return an existing ChatSession or create a new one.
+
+    Args:
+        db: Async database session.
+        user: Authenticated user (provides firm_id, id).
+        matter_id: Matter being queried.
+        session_id: Client-supplied session UUID, or None to create.
+
+    Returns:
+        The ChatSession ORM object.
+
+    Raises:
+        HTTPException(404): If a supplied session_id doesn't belong to
+            this user's firm + matter.
+    """
+    if session_id is not None:
+        result = await db.execute(
+            select(ChatSession).where(
+                ChatSession.id == session_id,
+                ChatSession.firm_id == user.firm_id,
+                ChatSession.matter_id == matter_id,
+            )
+        )
+        session = result.scalar_one_or_none()
+        if session is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+        return session
+
+    session = ChatSession(
+        firm_id=user.firm_id,
+        matter_id=matter_id,
+        created_by=user.id,
+        title=None,
+    )
+    db.add(session)
+    await db.flush()  # assign id without committing
+    return session
+
+
+async def _save_query(
+    db: AsyncSession,
+    session: ChatSession,
+    user: User,
+    query: str,
+    response: str,
+    chunks: list[models.ScoredPoint],
+    latency_ms: int,
+) -> ChatQuery:
+    """Persist a ChatQuery row with retrieval context.
+
+    ``retrieval_context`` stores the document_id, chunk_index, and
+    similarity score for each retrieved chunk. The text itself lives in
+    Qdrant and is not duplicated here. Bates/page citation assembly is
+    deferred to Feature 7.5.
+
+    Args:
+        db: Async database session.
+        session: Parent ChatSession (must already have an id).
+        user: Authenticated user.
+        query: The user's question text.
+        response: The full LLM response text.
+        chunks: Retrieved Qdrant points (for retrieval_context logging).
+        latency_ms: Wall-clock ms from pipeline start to LLM response.
+
+    Returns:
+        The persisted ChatQuery ORM object.
+    """
+    retrieval_context = {
+        "chunks": [
+            {
+                "document_id": str((point.payload or {}).get("document_id", "")),
+                "chunk_index": int((point.payload or {}).get("chunk_index", 0)),
+                "score": round(float(point.score), 4),
+            }
+            for point in chunks
+        ]
+    }
+
+    chat_query = ChatQuery(
+        session_id=session.id,
+        user_id=user.id,
+        query=query,
+        response=response,
+        model_name=settings.chatbot.model,
+        retrieval_context=retrieval_context,
+        latency_ms=latency_ms,
+    )
+    db.add(chat_query)
+    await db.commit()
+    await db.refresh(chat_query)
+    return chat_query
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming entrypoint
+# ---------------------------------------------------------------------------
+
+
+async def run_query(
+    query: str,
+    user: User,
+    matter_id: uuid.UUID,
+    session_id: uuid.UUID | None,
+    db: AsyncSession,
+) -> tuple[ChatSession, ChatQuery]:
+    """Full non-streaming RAG pipeline: retrieve → prompt → infer → persist.
+
+    Steps (order is security-critical):
+      1. build_qdrant_filter — permission gate, always first
+      2. embed_query — vectorise the user's question
+      3. _to_qdrant_filter — convert abstract filter to Qdrant model
+      4. vectorstore.search — retrieve top-K permission-filtered chunks
+      5. build_messages — assemble SYSTEM_PROMPT + context + question
+      6. ChatOllama.ainvoke — run inference
+      7. _get_or_create_session + _save_query — persist to DB
+
+    Args:
+        query: The user's natural-language question.
+        user: Authenticated user from JWT.
+        matter_id: Matter to query (validated by build_qdrant_filter).
+        session_id: Existing session UUID, or None to create.
+        db: Async database session.
+
+    Returns:
+        Tuple of (ChatSession, ChatQuery) after DB commit.
+
+    Raises:
+        HTTPException(404): If the user has no access to the matter.
+        HTTPException(400): If matter_id is a system matter.
+        httpx.ConnectError: If Ollama is unreachable.
+    """
+    start = time.monotonic()
+
+    with tracer.start_as_current_span(
+        "rag.run_query",
+        attributes={"user.id": str(user.id), "matter.id": str(matter_id)},
+    ) as span:
+        try:
+            # 1. Permission gate — must be first
+            perm_filter = await build_qdrant_filter(user, matter_id, db)
+
+            # 2. Embed the query
+            query_vector = await embed_query(query)
+
+            # 3. Convert to Qdrant filter
+            qdrant_filter = _to_qdrant_filter(perm_filter)
+
+            # 4. Retrieve top-K permission-filtered chunks
+            vectorstore = get_vectorstore_service()
+            chunks = await vectorstore.search(
+                query_vector,
+                qdrant_filter,
+                settings.chatbot.retrieval_chunk_count,
+            )
+
+            # 5. Assemble prompt
+            messages = build_messages(settings.chatbot.system_prompt, query, chunks)
+
+            # 6. Run inference
+            llm = ChatOllama(
+                model=settings.chatbot.model,
+                temperature=settings.chatbot.temperature,
+                base_url=settings.chatbot.base_url,
+                num_predict=settings.chatbot.max_tokens,
+            )
+            ai_msg = await llm.ainvoke(messages)
+            response_text = str(ai_msg.content)
+
+            latency_ms = int((time.monotonic() - start) * 1000)
+            span.set_attribute("rag.latency_ms", latency_ms)
+            span.set_attribute("rag.chunk_count", len(chunks))
+
+            # 7. Persist
+            session = await _get_or_create_session(db, user, matter_id, session_id)
+            record = await _save_query(
+                db, session, user, query, response_text, chunks, latency_ms
+            )
+
+            return session, record
+
+        except Exception as exc:
+            span.set_status(StatusCode.ERROR, str(exc))
+            span.record_exception(exc)
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Streaming entrypoint
+# ---------------------------------------------------------------------------
+
+
+async def stream_query(
+    query: str,
+    user: User,
+    matter_id: uuid.UUID,
+    session_id: uuid.UUID | None,
+    db: AsyncSession,
+) -> AsyncGenerator[str, None]:
+    """Streaming RAG pipeline: retrieve → prompt → stream infer → persist.
+
+    Yields individual text tokens as they arrive from Ollama. After the
+    generator is exhausted, persists the full response to the database.
+    The db session (from FastAPI's Depends(get_db)) remains open until
+    the StreamingResponse generator is fully consumed, so the final
+    await is safe.
+
+    Steps 1–5 are identical to run_query. Step 6 uses ChatOllama.astream.
+
+    Args:
+        query: The user's natural-language question.
+        user: Authenticated user from JWT.
+        matter_id: Matter to query (validated by build_qdrant_filter).
+        session_id: Existing session UUID, or None to create.
+        db: Async database session.
+
+    Yields:
+        Individual response text tokens (strings).
+
+    Raises:
+        HTTPException(404): If the user has no access to the matter.
+        HTTPException(400): If matter_id is a system matter.
+        httpx.ConnectError: If Ollama is unreachable.
+    """
+    start = time.monotonic()
+
+    with tracer.start_as_current_span(
+        "rag.stream_query",
+        attributes={"user.id": str(user.id), "matter.id": str(matter_id)},
+    ) as span:
+        try:
+            # 1. Permission gate — must be first
+            perm_filter = await build_qdrant_filter(user, matter_id, db)
+
+            # 2. Embed the query
+            query_vector = await embed_query(query)
+
+            # 3. Convert to Qdrant filter
+            qdrant_filter = _to_qdrant_filter(perm_filter)
+
+            # 4. Retrieve top-K permission-filtered chunks
+            vectorstore = get_vectorstore_service()
+            chunks = await vectorstore.search(
+                query_vector,
+                qdrant_filter,
+                settings.chatbot.retrieval_chunk_count,
+            )
+
+            # 5. Assemble prompt
+            messages = build_messages(settings.chatbot.system_prompt, query, chunks)
+
+            # 6. Stream inference
+            llm = ChatOllama(
+                model=settings.chatbot.model,
+                temperature=settings.chatbot.temperature,
+                base_url=settings.chatbot.base_url,
+                num_predict=settings.chatbot.max_tokens,
+            )
+
+            full_response: list[str] = []
+            async for chunk in llm.astream(messages):
+                token = str(chunk.content)
+                full_response.append(token)
+                yield token
+
+            latency_ms = int((time.monotonic() - start) * 1000)
+            span.set_attribute("rag.latency_ms", latency_ms)
+            span.set_attribute("rag.chunk_count", len(chunks))
+
+            # 7. Persist — db session is still alive at this point
+            session = await _get_or_create_session(db, user, matter_id, session_id)
+            await _save_query(
+                db, session, user, query, "".join(full_response), chunks, latency_ms
+            )
+
+        except Exception as exc:
+            span.set_status(StatusCode.ERROR, str(exc))
+            span.record_exception(exc)
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Public re-exports (for import convenience in chats.py)
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    "build_messages",
+    "embed_query",
+    "run_query",
+    "stream_query",
+]

--- a/backend/app/vectorstore/models.py
+++ b/backend/app/vectorstore/models.py
@@ -16,6 +16,10 @@ class VectorPayload(TypedDict):
 
     Every vector stored in Qdrant must carry these fields so that
     ``build_qdrant_filter()`` can enforce RBAC on every query.
+
+    ``text`` stores the raw chunk text so that the RAG pipeline can
+    build context blocks directly from search results without a
+    separate MinIO fetch.
     """
 
     firm_id: str
@@ -27,6 +31,7 @@ class VectorPayload(TypedDict):
     source: str
     bates_number: str | None
     page_number: int | None
+    text: str
 
 
 # Keys that must be present in payload_metadata passed to the task.

--- a/backend/app/vectorstore/service.py
+++ b/backend/app/vectorstore/service.py
@@ -15,6 +15,9 @@ from app.core.metrics import (
     vectorstore_delete_completed,
     vectorstore_delete_duration_seconds,
     vectorstore_delete_failed,
+    vectorstore_search_completed,
+    vectorstore_search_duration_seconds,
+    vectorstore_search_failed,
     vectorstore_upsert_completed,
     vectorstore_upsert_duration_seconds,
     vectorstore_upsert_failed,
@@ -230,6 +233,74 @@ class QdrantVectorStore:
                 )
                 raise
 
+    async def search(
+        self,
+        query_vector: list[float],
+        qdrant_filter: models.Filter,
+        limit: int,
+    ) -> list[models.ScoredPoint]:
+        """Similarity search with mandatory RBAC filter applied.
+
+        Args:
+            query_vector: Embedded query vector.
+            qdrant_filter: Pre-built filter from ``build_qdrant_filter()``
+                converted to ``qdrant_client.models.Filter``. Never
+                bypass or accept a client-supplied filter here.
+            limit: Maximum number of results to return.
+
+        Returns:
+            Scored points sorted by descending similarity, with full
+            payload (including ``text``) attached.
+        """
+        start_time = time.monotonic()
+
+        with tracer.start_as_current_span(
+            "vectorstore.search",
+            attributes={
+                "vectorstore.collection": self._collection,
+                "vectorstore.limit": limit,
+            },
+        ) as span:
+            try:
+                response = await self._client.query_points(
+                    collection_name=self._collection,
+                    query=query_vector,
+                    query_filter=qdrant_filter,
+                    limit=limit,
+                    with_payload=True,
+                )
+                results = response.points
+
+                span.set_attribute("vectorstore.result_count", len(results))
+
+                elapsed = time.monotonic() - start_time
+                attrs = {"collection": self._collection}
+                vectorstore_search_completed.add(1, attrs)
+                vectorstore_search_duration_seconds.record(elapsed, attrs)
+
+                logger.debug(
+                    "Search returned %d results from collection %r",
+                    len(results),
+                    self._collection,
+                )
+                return results
+
+            except Exception as exc:
+                elapsed = time.monotonic() - start_time
+                span.set_status(StatusCode.ERROR, str(exc))
+                span.record_exception(exc)
+                vectorstore_search_failed.add(
+                    1,
+                    {
+                        "collection": self._collection,
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                vectorstore_search_duration_seconds.record(
+                    elapsed, {"collection": self._collection}
+                )
+                raise
+
     async def close(self) -> None:
         """Close the underlying Qdrant client connection."""
         await self._client.close()
@@ -250,6 +321,7 @@ class QdrantVectorStore:
             "source": str(payload_metadata["source"]),
             "bates_number": payload_metadata.get("bates_number"),  # type: ignore[typeddict-item]
             "page_number": payload_metadata.get("page_number"),  # type: ignore[typeddict-item]
+            "text": emb.text,
         }
 
         return models.PointStruct(

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -1,14 +1,17 @@
 """Unit tests for the /chats API endpoints.
 
 Uses AsyncClient + in-memory overrides via FakeSession / api_client from conftest.py.
-The RAG pipeline is not yet wired — endpoints return stub responses.
+The RAG pipeline is mocked at the import boundary so no running services are needed.
 """
 
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException, status
 from shared.models.enums import Role
 
 from tests.conftest import FakeSession, api_client, auth_header
@@ -16,6 +19,27 @@ from tests.factories import make_user
 
 _FIRM_ID = uuid.uuid4()
 _MATTER_ID = uuid.uuid4()
+_SESSION_ID = uuid.uuid4()
+_QUERY_ID = uuid.uuid4()
+
+
+def _make_fake_session_obj() -> MagicMock:
+    s = MagicMock()
+    s.id = _SESSION_ID
+    s.firm_id = _FIRM_ID
+    s.matter_id = _MATTER_ID
+    return s
+
+
+def _make_fake_query_obj(response: str = "The answer is 42.") -> MagicMock:
+    q = MagicMock()
+    q.id = _QUERY_ID
+    q.session_id = _SESSION_ID
+    q.query = "What Brady material exists?"
+    q.response = response
+    q.model_name = "llama3"
+    q.created_at = datetime.now(UTC)
+    return q
 
 
 # ---------------------------------------------------------------------------
@@ -25,43 +49,82 @@ _MATTER_ID = uuid.uuid4()
 
 class TestSubmitQuery:
     @pytest.mark.asyncio
-    async def test_stub_returns_201_with_canned_response(self) -> None:
+    async def test_returns_201_with_real_response(self) -> None:
         user = make_user(firm_id=_FIRM_ID, role=Role.admin)
         fake = FakeSession()
-        async with api_client(user, fake) as ac:
-            resp = await ac.post(
-                "/chats/",
-                json={
-                    "matter_id": str(_MATTER_ID),
-                    "query": "What Brady material exists?",
-                },
-                headers=auth_header(user),
-            )
+        fake_session = _make_fake_session_obj()
+        fake_query = _make_fake_query_obj()
+
+        with patch(
+            "app.api.chats.run_query",
+            AsyncMock(return_value=(fake_session, fake_query)),
+        ):
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    "/chats/",
+                    json={
+                        "matter_id": str(_MATTER_ID),
+                        "query": "What Brady material exists?",
+                    },
+                    headers=auth_header(user),
+                )
+
         assert resp.status_code == 201
         data = resp.json()
         assert data["query"] == "What Brady material exists?"
         assert data["matter_id"] == str(_MATTER_ID)
-        assert "stub" in data["response"].lower()
-        assert "session_id" in data
-        assert "id" in data
+        assert data["response"] == "The answer is 42."
+        assert data["session_id"] == str(_SESSION_ID)
+        assert data["id"] == str(_QUERY_ID)
+        # No longer a stub response
+        assert "stub" not in data["response"].lower()
 
     @pytest.mark.asyncio
     async def test_with_explicit_session_id(self) -> None:
         user = make_user(firm_id=_FIRM_ID, role=Role.admin)
-        session_id = uuid.uuid4()
         fake = FakeSession()
-        async with api_client(user, fake) as ac:
-            resp = await ac.post(
-                "/chats/",
-                json={
-                    "matter_id": str(_MATTER_ID),
-                    "session_id": str(session_id),
-                    "query": "Who are the witnesses?",
-                },
-                headers=auth_header(user),
-            )
+        fake_session = _make_fake_session_obj()
+        fake_query = _make_fake_query_obj()
+
+        with patch(
+            "app.api.chats.run_query",
+            AsyncMock(return_value=(fake_session, fake_query)),
+        ):
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    "/chats/",
+                    json={
+                        "matter_id": str(_MATTER_ID),
+                        "session_id": str(_SESSION_ID),
+                        "query": "Who are the witnesses?",
+                    },
+                    headers=auth_header(user),
+                )
+
         assert resp.status_code == 201
-        assert resp.json()["session_id"] == str(session_id)
+        assert resp.json()["session_id"] == str(_SESSION_ID)
+
+    @pytest.mark.asyncio
+    async def test_matter_access_denied_returns_404(self) -> None:
+        """build_qdrant_filter raises 404 when user has no matter access."""
+        user = make_user(firm_id=_FIRM_ID, role=Role.attorney)
+        fake = FakeSession()
+
+        with patch(
+            "app.api.chats.run_query",
+            AsyncMock(side_effect=HTTPException(status_code=status.HTTP_404_NOT_FOUND)),
+        ):
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    "/chats/",
+                    json={
+                        "matter_id": str(_MATTER_ID),
+                        "query": "What Brady material exists?",
+                    },
+                    headers=auth_header(user),
+                )
+
+        assert resp.status_code == 404
 
     @pytest.mark.asyncio
     async def test_requires_authentication(self) -> None:
@@ -115,6 +178,118 @@ class TestSubmitQuery:
             resp = await ac.post(
                 "/chats/",
                 json={"matter_id": str(_MATTER_ID)},
+                headers=auth_header(user),
+            )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /chats/stream
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitQueryStream:
+    @pytest.mark.asyncio
+    async def test_returns_sse_content_type(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+
+        async def _fake_stream(*_a: object, **_kw: object):  # type: ignore[return]
+            yield "Hello"
+            yield " world"
+
+        with patch("app.api.chats.stream_query", _fake_stream):
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    "/chats/stream",
+                    json={
+                        "matter_id": str(_MATTER_ID),
+                        "query": "What Brady material exists?",
+                    },
+                    headers=auth_header(user),
+                )
+
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+
+    @pytest.mark.asyncio
+    async def test_response_body_contains_sse_data_lines(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+
+        async def _fake_stream(*_a: object, **_kw: object):  # type: ignore[return]
+            yield "Hello"
+            yield " world"
+
+        with patch("app.api.chats.stream_query", _fake_stream):
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    "/chats/stream",
+                    json={
+                        "matter_id": str(_MATTER_ID),
+                        "query": "What Brady material exists?",
+                    },
+                    headers=auth_header(user),
+                )
+
+        body = resp.text
+        assert "data:" in body
+        assert "[DONE]" in body
+
+    @pytest.mark.asyncio
+    async def test_requires_authentication(self) -> None:
+        from httpx import ASGITransport, AsyncClient
+
+        from app.main import app
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post(
+                "/chats/stream",
+                json={
+                    "matter_id": str(_MATTER_ID),
+                    "query": "Test query",
+                },
+            )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_error_mid_stream_yields_error_frame_then_done(self) -> None:
+        """Exceptions raised inside stream_query produce an SSE error frame."""
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+
+        async def _failing_stream(*_a: object, **_kw: object):  # type: ignore[return]
+            yield "partial"
+            raise RuntimeError("Ollama disconnected")
+
+        with patch("app.api.chats.stream_query", _failing_stream):
+            async with api_client(user, fake) as ac:
+                resp = await ac.post(
+                    "/chats/stream",
+                    json={
+                        "matter_id": str(_MATTER_ID),
+                        "query": "What Brady material exists?",
+                    },
+                    headers=auth_header(user),
+                )
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Ollama disconnected" in body
+        assert "[DONE]" in body
+
+    @pytest.mark.asyncio
+    async def test_validation_rejects_empty_query(self) -> None:
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        fake = FakeSession()
+        async with api_client(user, fake) as ac:
+            resp = await ac.post(
+                "/chats/stream",
+                json={
+                    "matter_id": str(_MATTER_ID),
+                    "query": "",
+                },
                 headers=auth_header(user),
             )
         assert resp.status_code == 422

--- a/backend/tests/test_rag_pipeline.py
+++ b/backend/tests/test_rag_pipeline.py
@@ -1,0 +1,527 @@
+"""Unit tests for the RAG pipeline (backend/app/rag/pipeline.py).
+
+All external dependencies (httpx, Qdrant, ChatOllama, DB) are mocked.
+No running services required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from qdrant_client import models
+from shared.models.enums import Role
+
+from app.core.constants import GLOBAL_KNOWLEDGE_MATTER_ID
+from app.core.permissions import PermissionFilter
+from app.rag.pipeline import (
+    _format_context,
+    _to_qdrant_filter,
+    build_messages,
+    embed_query,
+    run_query,
+    stream_query,
+)
+from tests.conftest import FakeSession
+from tests.factories import make_user
+
+_FIRM_ID = uuid.uuid4()
+_MATTER_ID = uuid.uuid4()
+_DOC_ID = str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_scored_point(
+    doc_id: str = _DOC_ID,
+    chunk_index: int = 0,
+    text: str = "Sample chunk text.",
+    score: float = 0.87,
+    page_number: int | None = 4,
+    bates_number: str | None = "DEF-0042",
+) -> models.ScoredPoint:
+    """Build a minimal ScoredPoint as Qdrant would return from search."""
+    return models.ScoredPoint(
+        id=str(uuid.uuid4()),
+        version=0,
+        score=score,
+        payload={
+            "firm_id": str(_FIRM_ID),
+            "matter_id": str(_MATTER_ID),
+            "client_id": str(uuid.uuid4()),
+            "document_id": doc_id,
+            "chunk_index": chunk_index,
+            "classification": "unclassified",
+            "source": "government_production",
+            "bates_number": bates_number,
+            "page_number": page_number,
+            "text": text,
+        },
+    )
+
+
+def _make_perm_filter(
+    excluded: frozenset[str] | None = None,
+) -> PermissionFilter:
+    return PermissionFilter(
+        firm_id=_FIRM_ID,
+        matter_ids=frozenset({_MATTER_ID, GLOBAL_KNOWLEDGE_MATTER_ID}),
+        excluded_classifications=excluded or frozenset(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# embed_query
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedQuery:
+    @pytest.mark.asyncio
+    async def test_calls_ollama_embed_endpoint(self) -> None:
+        vector = [0.1] * 768
+        mock_response = httpx.Response(
+            200,
+            json={"embeddings": [vector]},
+            request=httpx.Request("POST", "http://ollama:11434/api/embed"),
+        )
+        with patch("app.rag.pipeline.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            result = await embed_query("test query")
+
+        assert result == vector
+        mock_client.post.assert_called_once()
+        call_kwargs = mock_client.post.call_args
+        body = call_kwargs[1]["json"] if "json" in call_kwargs[1] else call_kwargs[0][1]
+        assert body["input"] == ["test query"]
+
+    @pytest.mark.asyncio
+    async def test_http_error_propagates(self) -> None:
+        mock_response = httpx.Response(
+            500,
+            text="Internal Server Error",
+            request=httpx.Request("POST", "http://ollama:11434/api/embed"),
+        )
+        with patch("app.rag.pipeline.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.return_value = mock_response
+
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await embed_query("test query")
+
+
+# ---------------------------------------------------------------------------
+# _to_qdrant_filter
+# ---------------------------------------------------------------------------
+
+
+class TestToQdrantFilter:
+    @pytest.mark.parametrize(
+        ("excluded", "expect_must_not"),
+        [
+            (frozenset(), False),  # admin — no exclusions
+            (frozenset({"jencks"}), True),  # attorney / paralegal
+            (frozenset({"jencks", "work_product"}), True),  # investigator
+        ],
+    )
+    def test_must_not_present_based_on_exclusions(
+        self, excluded: frozenset[str], expect_must_not: bool
+    ) -> None:
+        pf = _make_perm_filter(excluded=excluded)
+        f = _to_qdrant_filter(pf)
+        has_must_not = bool(f.must_not)
+        assert has_must_not == expect_must_not
+
+    def test_both_matter_ids_in_match_any(self) -> None:
+        pf = _make_perm_filter()
+        f = _to_qdrant_filter(pf)
+
+        matter_condition = next(
+            c
+            for c in (f.must or [])
+            if isinstance(c, models.FieldCondition) and c.key == "matter_id"
+        )
+        any_values = matter_condition.match.any  # type: ignore[union-attr]
+        assert str(_MATTER_ID) in any_values
+        assert str(GLOBAL_KNOWLEDGE_MATTER_ID) in any_values
+
+    def test_firm_id_in_must(self) -> None:
+        pf = _make_perm_filter()
+        f = _to_qdrant_filter(pf)
+        firm_condition = next(
+            c
+            for c in (f.must or [])
+            if isinstance(c, models.FieldCondition) and c.key == "firm_id"
+        )
+        assert firm_condition.match.value == str(_FIRM_ID)  # type: ignore[union-attr]
+
+    def test_excluded_classifications_in_must_not(self) -> None:
+        pf = _make_perm_filter(excluded=frozenset({"jencks", "work_product"}))
+        f = _to_qdrant_filter(pf)
+        class_condition = next(
+            c
+            for c in (f.must_not or [])
+            if isinstance(c, models.FieldCondition) and c.key == "classification"
+        )
+        any_values = class_condition.match.any  # type: ignore[union-attr]
+        assert "jencks" in any_values
+        assert "work_product" in any_values
+
+
+# ---------------------------------------------------------------------------
+# _format_context
+# ---------------------------------------------------------------------------
+
+
+class TestFormatContext:
+    def test_empty_chunks_returns_no_documents_message(self) -> None:
+        result = _format_context([])
+        assert "no" in result.lower() or "not found" in result.lower()
+
+    def test_with_bates_and_page(self) -> None:
+        point = _make_scored_point(page_number=4, bates_number="DEF-0042")
+        result = _format_context([point])
+        assert "Page: 4" in result
+        assert "Bates: DEF-0042" in result
+
+    def test_without_bates_or_page(self) -> None:
+        point = _make_scored_point(page_number=None, bates_number=None)
+        result = _format_context([point])
+        assert "Page:" not in result
+        assert "Bates:" not in result
+
+    def test_chunk_text_appears_in_output(self) -> None:
+        point = _make_scored_point(text="Officer observed the defendant at 3rd Ave.")
+        result = _format_context([point])
+        assert "Officer observed the defendant at 3rd Ave." in result
+
+    def test_multiple_chunks_numbered(self) -> None:
+        points = [
+            _make_scored_point(text="First chunk."),
+            _make_scored_point(text="Second chunk."),
+        ]
+        result = _format_context(points)
+        assert "Source 1" in result
+        assert "Source 2" in result
+
+
+# ---------------------------------------------------------------------------
+# build_messages
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMessages:
+    def test_returns_two_messages(self) -> None:
+        msgs = build_messages("You are Gideon.", "What evidence?", [])
+        assert len(msgs) == 2
+
+    def test_roles_are_system_and_user(self) -> None:
+        msgs = build_messages("You are Gideon.", "What evidence?", [])
+        assert msgs[0]["role"] == "system"
+        assert msgs[1]["role"] == "user"
+
+    def test_system_prompt_in_system_message(self) -> None:
+        prompt = "Custom system prompt for testing."
+        msgs = build_messages(prompt, "question?", [])
+        assert msgs[0]["content"] == prompt
+
+    def test_query_in_user_message(self) -> None:
+        msgs = build_messages("sys", "What Brady material exists?", [])
+        assert "What Brady material exists?" in msgs[1]["content"]
+
+    def test_chunk_text_in_user_message(self) -> None:
+        point = _make_scored_point(text="Highly relevant passage.")
+        msgs = build_messages("sys", "query?", [point])
+        assert "Highly relevant passage." in msgs[1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# run_query
+# ---------------------------------------------------------------------------
+
+
+def _make_chat_session() -> MagicMock:
+    session = MagicMock()
+    session.id = uuid.uuid4()
+    session.firm_id = _FIRM_ID
+    session.matter_id = _MATTER_ID
+    return session
+
+
+def _make_chat_query(session_id: uuid.UUID) -> MagicMock:
+    q = MagicMock()
+    q.id = uuid.uuid4()
+    q.session_id = session_id
+    q.query = "test query"
+    q.response = "test response"
+    q.model_name = "llama3"
+    q.latency_ms = 1234
+    q.created_at = datetime.now(UTC)
+    return q
+
+
+class TestRunQuery:
+    @pytest.mark.asyncio
+    async def test_build_qdrant_filter_called_before_search(self) -> None:
+        """build_qdrant_filter must be the first external call."""
+        call_order: list[str] = []
+        pf = _make_perm_filter()
+        fake_session = _make_chat_session()
+        fake_query = _make_chat_query(fake_session.id)
+
+        async def _mock_filter(*_: object, **__: object) -> PermissionFilter:
+            call_order.append("filter")
+            return pf
+
+        async def _mock_embed(*_: object, **__: object) -> list[float]:
+            call_order.append("embed")
+            return [0.1] * 768
+
+        mock_vectorstore = AsyncMock()
+        mock_vectorstore.search.side_effect = lambda *_a, **_kw: (
+            call_order.append("search") or []
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="the answer"))
+
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        db = FakeSession()
+
+        with (
+            patch("app.rag.pipeline.build_qdrant_filter", _mock_filter),
+            patch("app.rag.pipeline.embed_query", _mock_embed),
+            patch(
+                "app.rag.pipeline.get_vectorstore_service",
+                return_value=mock_vectorstore,
+            ),
+            patch("app.rag.pipeline.ChatOllama", return_value=mock_llm),
+            patch(
+                "app.rag.pipeline._get_or_create_session",
+                AsyncMock(return_value=fake_session),
+            ),
+            patch("app.rag.pipeline._save_query", AsyncMock(return_value=fake_query)),
+        ):
+            await run_query("test query", user, _MATTER_ID, None, db)
+
+        assert call_order[0] == "filter"
+        assert "embed" in call_order
+        assert "search" in call_order
+
+    @pytest.mark.asyncio
+    async def test_returns_session_and_query(self) -> None:
+        pf = _make_perm_filter()
+        fake_session = _make_chat_session()
+        fake_query = _make_chat_query(fake_session.id)
+
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="the answer"))
+        mock_vectorstore = AsyncMock()
+        mock_vectorstore.search.return_value = []
+
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        db = FakeSession()
+
+        with (
+            patch("app.rag.pipeline.build_qdrant_filter", AsyncMock(return_value=pf)),
+            patch("app.rag.pipeline.embed_query", AsyncMock(return_value=[0.1] * 768)),
+            patch(
+                "app.rag.pipeline.get_vectorstore_service",
+                return_value=mock_vectorstore,
+            ),
+            patch("app.rag.pipeline.ChatOllama", return_value=mock_llm),
+            patch(
+                "app.rag.pipeline._get_or_create_session",
+                AsyncMock(return_value=fake_session),
+            ),
+            patch("app.rag.pipeline._save_query", AsyncMock(return_value=fake_query)),
+        ):
+            session, record = await run_query("test query", user, _MATTER_ID, None, db)
+
+        assert session is fake_session
+        assert record is fake_query
+
+    @pytest.mark.asyncio
+    async def test_saves_to_db(self) -> None:
+        pf = _make_perm_filter()
+        fake_session = _make_chat_session()
+        fake_query = _make_chat_query(fake_session.id)
+
+        mock_save = AsyncMock(return_value=fake_query)
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(return_value=MagicMock(content="answer"))
+        mock_vectorstore = AsyncMock()
+        mock_vectorstore.search.return_value = []
+
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        db = FakeSession()
+
+        with (
+            patch("app.rag.pipeline.build_qdrant_filter", AsyncMock(return_value=pf)),
+            patch("app.rag.pipeline.embed_query", AsyncMock(return_value=[0.1] * 768)),
+            patch(
+                "app.rag.pipeline.get_vectorstore_service",
+                return_value=mock_vectorstore,
+            ),
+            patch("app.rag.pipeline.ChatOllama", return_value=mock_llm),
+            patch(
+                "app.rag.pipeline._get_or_create_session",
+                AsyncMock(return_value=fake_session),
+            ),
+            patch("app.rag.pipeline._save_query", mock_save),
+        ):
+            await run_query("my question", user, _MATTER_ID, None, db)
+
+        mock_save.assert_awaited_once()
+        # First positional arg after db, session, user is the query text
+        assert mock_save.call_args[0][3] == "my question"
+        assert mock_save.call_args[0][4] == "answer"
+
+
+# ---------------------------------------------------------------------------
+# stream_query
+# ---------------------------------------------------------------------------
+
+
+class TestStreamQuery:
+    @pytest.mark.asyncio
+    async def test_yields_tokens_from_llm(self) -> None:
+        pf = _make_perm_filter()
+        fake_session = _make_chat_session()
+        fake_query = _make_chat_query(fake_session.id)
+
+        async def _fake_astream(_messages: object) -> Any:
+            for tok in ["Hello", " world", "."]:
+                yield MagicMock(content=tok)
+
+        mock_llm = MagicMock()
+        mock_llm.astream = _fake_astream
+        mock_vectorstore = AsyncMock()
+        mock_vectorstore.search.return_value = []
+
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        db = FakeSession()
+
+        tokens: list[str] = []
+        with (
+            patch("app.rag.pipeline.build_qdrant_filter", AsyncMock(return_value=pf)),
+            patch("app.rag.pipeline.embed_query", AsyncMock(return_value=[0.1] * 768)),
+            patch(
+                "app.rag.pipeline.get_vectorstore_service",
+                return_value=mock_vectorstore,
+            ),
+            patch("app.rag.pipeline.ChatOllama", return_value=mock_llm),
+            patch(
+                "app.rag.pipeline._get_or_create_session",
+                AsyncMock(return_value=fake_session),
+            ),
+            patch("app.rag.pipeline._save_query", AsyncMock(return_value=fake_query)),
+        ):
+            async for token in stream_query("test query", user, _MATTER_ID, None, db):
+                tokens.append(token)
+
+        assert tokens == ["Hello", " world", "."]
+
+    @pytest.mark.asyncio
+    async def test_saves_to_db_after_all_tokens_yielded(self) -> None:
+        pf = _make_perm_filter()
+        fake_session = _make_chat_session()
+        fake_query = _make_chat_query(fake_session.id)
+
+        yielded: list[str] = []
+        saved_at_token_count: list[int] = []
+
+        async def _fake_astream(_messages: object) -> Any:
+            for tok in ["A", "B", "C"]:
+                yielded.append(tok)
+                yield MagicMock(content=tok)
+
+        mock_save = AsyncMock(
+            side_effect=lambda *_a, **_kw: (
+                saved_at_token_count.append(len(yielded)) or fake_query
+            )
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.astream = _fake_astream
+        mock_vectorstore = AsyncMock()
+        mock_vectorstore.search.return_value = []
+
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        db = FakeSession()
+
+        with (
+            patch("app.rag.pipeline.build_qdrant_filter", AsyncMock(return_value=pf)),
+            patch("app.rag.pipeline.embed_query", AsyncMock(return_value=[0.1] * 768)),
+            patch(
+                "app.rag.pipeline.get_vectorstore_service",
+                return_value=mock_vectorstore,
+            ),
+            patch("app.rag.pipeline.ChatOllama", return_value=mock_llm),
+            patch(
+                "app.rag.pipeline._get_or_create_session",
+                AsyncMock(return_value=fake_session),
+            ),
+            patch("app.rag.pipeline._save_query", mock_save),
+        ):
+            async for _ in stream_query("test query", user, _MATTER_ID, None, db):
+                pass
+
+        # save must have been called after all 3 tokens were yielded
+        mock_save.assert_awaited_once()
+        assert saved_at_token_count[0] == 3
+
+    @pytest.mark.asyncio
+    async def test_full_response_joined_before_save(self) -> None:
+        pf = _make_perm_filter()
+        fake_session = _make_chat_session()
+        fake_query = _make_chat_query(fake_session.id)
+
+        async def _fake_astream(_messages: object) -> Any:
+            for tok in ["Hello", " ", "world"]:
+                yield MagicMock(content=tok)
+
+        mock_save = AsyncMock(return_value=fake_query)
+        mock_llm = MagicMock()
+        mock_llm.astream = _fake_astream
+        mock_vectorstore = AsyncMock()
+        mock_vectorstore.search.return_value = []
+
+        user = make_user(firm_id=_FIRM_ID, role=Role.admin)
+        db = FakeSession()
+
+        with (
+            patch("app.rag.pipeline.build_qdrant_filter", AsyncMock(return_value=pf)),
+            patch("app.rag.pipeline.embed_query", AsyncMock(return_value=[0.1] * 768)),
+            patch(
+                "app.rag.pipeline.get_vectorstore_service",
+                return_value=mock_vectorstore,
+            ),
+            patch("app.rag.pipeline.ChatOllama", return_value=mock_llm),
+            patch(
+                "app.rag.pipeline._get_or_create_session",
+                AsyncMock(return_value=fake_session),
+            ),
+            patch("app.rag.pipeline._save_query", mock_save),
+        ):
+            async for _ in stream_query("q", user, _MATTER_ID, None, db):
+                pass
+
+        # response argument (positional index 4) should be joined tokens
+        saved_response = mock_save.call_args[0][4]
+        assert saved_response == "Hello world"

--- a/backend/tests/test_vectorstore.py
+++ b/backend/tests/test_vectorstore.py
@@ -30,7 +30,7 @@ class TestVectorPayload:
     def test_required_metadata_keys_are_subset_of_payload(self) -> None:
         payload_keys = set(VectorPayload.__annotations__)
         # Required metadata keys + per-chunk keys = full payload
-        per_chunk_keys = {"document_id", "chunk_index"}
+        per_chunk_keys = {"document_id", "chunk_index", "text"}
         optional_keys = {"bates_number", "page_number"}
         assert REQUIRED_METADATA_KEYS | per_chunk_keys | optional_keys == payload_keys
 

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -229,6 +229,10 @@ services:
       - OLLAMA_HOST=http://ollama:11434
       - EMBEDDING_MODEL=${GIDEON_EMBEDDING_MODEL:-nomic-embed-text}
       - CHATBOT_MODEL=${GIDEON_CHATBOT_MODEL:-llama3}
+      # Optional: comma-separated list of additional models to pre-pull.
+      # These are stored in the ollama-models volume and survive restarts.
+      # Example: GIDEON_ADDITIONAL_MODELS=mistral,qwen3:8b
+      - ADDITIONAL_MODELS=${GIDEON_ADDITIONAL_MODELS:-}
     entrypoint: >
       /bin/sh -c "
       echo 'Pulling embedding model $$EMBEDDING_MODEL...';
@@ -237,6 +241,16 @@ services:
       echo 'Pulling LLM model $$CHATBOT_MODEL...';
       ollama pull $$CHATBOT_MODEL;
       echo 'LLM model pull complete.';
+      if [ -n \"$$ADDITIONAL_MODELS\" ]; then
+        echo \"$$ADDITIONAL_MODELS\" | tr ',' '\n' | while IFS= read -r model; do
+          model=$$(echo \"$$model\" | tr -d ' ');
+          [ -z \"$$model\" ] && continue;
+          echo \"Pulling additional model $$model...\";
+          ollama pull $$model;
+          echo \"Done: $$model\";
+        done;
+      fi;
+      echo 'All model pulls complete.';
       "
     networks:
       - gideon

--- a/scripts/backfill_chunk_text.py
+++ b/scripts/backfill_chunk_text.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Backfill the 'text' payload field on existing Qdrant points.
+
+Documents ingested before Feature 7.3 do not carry chunk text in their
+Qdrant payload.  This script scrolls all affected points, fetches the
+text from the corresponding chunks.json in MinIO, and patches each
+point in place using set_payload.  No re-ingestion required.
+
+Usage:
+    python scripts/backfill_chunk_text.py
+
+    # Limit to one firm or matter:
+    python scripts/backfill_chunk_text.py --firm-id <uuid>
+    python scripts/backfill_chunk_text.py --firm-id <uuid> --matter-id <uuid>
+
+    # Dry-run (shows what would be patched, writes nothing):
+    python scripts/backfill_chunk_text.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+
+import httpx
+from minio import Minio  # type: ignore[import-untyped]
+from qdrant_client import QdrantClient, models
+
+# ---------------------------------------------------------------------------
+# Constants — mirror defaults from app/core/config.py
+# ---------------------------------------------------------------------------
+
+QDRANT_URL = "http://localhost:6333"
+COLLECTION = "gideon"
+MINIO_ENDPOINT = "localhost:9000"
+MINIO_ACCESS_KEY = "gideon"
+MINIO_SECRET_KEY = "changeme"
+MINIO_BUCKET = "gideon"
+
+SCROLL_BATCH = 100  # points per scroll page
+
+
+# ---------------------------------------------------------------------------
+# MinIO helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_chunks_json(s3: Minio, firm_id: str, matter_id: str, document_id: str) -> list[dict]:
+    """Return the full chunks list for a document from MinIO."""
+    key = f"{firm_id}/{matter_id}/{document_id}/chunks.json"
+    response = s3.get_object(MINIO_BUCKET, key)
+    try:
+        data = json.loads(response.read())
+    finally:
+        response.close()
+        response.release_conn()
+    return data["chunks"]
+
+
+# ---------------------------------------------------------------------------
+# Scroll helpers
+# ---------------------------------------------------------------------------
+
+
+def build_scroll_filter(firm_id: str | None, matter_id: str | None) -> models.Filter | None:
+    must: list[models.FieldCondition] = []
+    if firm_id:
+        must.append(models.FieldCondition(key="firm_id", match=models.MatchValue(value=firm_id)))
+    if matter_id:
+        must.append(models.FieldCondition(key="matter_id", match=models.MatchValue(value=matter_id)))
+    return models.Filter(must=must) if must else None
+
+
+def scroll_all_points(
+    client: QdrantClient,
+    scroll_filter: models.Filter | None,
+) -> list[models.ScoredPoint]:
+    """Page through the collection and return all points (with payload)."""
+    all_points: list = []
+    offset = None
+
+    while True:
+        results, next_offset = client.scroll(
+            collection_name=COLLECTION,
+            scroll_filter=scroll_filter,
+            limit=SCROLL_BATCH,
+            offset=offset,
+            with_payload=True,
+            with_vectors=False,
+        )
+        all_points.extend(results)
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    return all_points
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill 'text' payload field on pre-Feature-7.3 Qdrant points."
+    )
+    parser.add_argument("--firm-id", default=None, help="Limit to a single firm UUID.")
+    parser.add_argument("--matter-id", default=None, help="Limit to a single matter UUID.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be patched without writing anything.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    print(f"Qdrant:  {QDRANT_URL}  collection={COLLECTION}")
+    print(f"MinIO:   {MINIO_ENDPOINT}  bucket={MINIO_BUCKET}")
+    if args.firm_id:
+        print(f"Filter:  firm_id={args.firm_id}")
+    if args.matter_id:
+        print(f"         matter_id={args.matter_id}")
+    if args.dry_run:
+        print("Mode:    DRY RUN — no writes")
+    print()
+
+    qdrant = QdrantClient(
+        url=QDRANT_URL,
+        timeout=60,
+        # Disable keep-alive pooling to avoid WinError 10054 on Windows
+        limits=httpx.Limits(max_keepalive_connections=0, max_connections=10),
+    )
+    s3 = Minio(
+        MINIO_ENDPOINT,
+        access_key=MINIO_ACCESS_KEY,
+        secret_key=MINIO_SECRET_KEY,
+        secure=False,
+    )
+
+    # 1. Scroll all points (optionally filtered by firm/matter)
+    print("Scrolling points...", flush=True)
+    scroll_filter = build_scroll_filter(args.firm_id, args.matter_id)
+    all_points = scroll_all_points(qdrant, scroll_filter)
+    print(f"Found {len(all_points)} total point(s).")
+
+    # 2. Find points missing 'text'
+    missing = [p for p in all_points if not (p.payload or {}).get("text")]
+    print(f"Points missing 'text': {len(missing)}")
+
+    if not missing:
+        print("Nothing to patch.")
+        return
+
+    # 3. Group by (firm_id, matter_id, document_id) to batch MinIO fetches
+    groups: dict[tuple[str, str, str], list] = defaultdict(list)
+    for point in missing:
+        p = point.payload or {}
+        key = (str(p.get("firm_id", "")), str(p.get("matter_id", "")), str(p.get("document_id", "")))
+        groups[key].append(point)
+
+    print(f"Unique documents to fetch from MinIO: {len(groups)}")
+    print(f"Estimated time: ~{len(missing) // 10}–{len(missing) // 5}s (10–20 points/sec on localhost)\n")
+
+    # 4. For each document, fetch chunks.json and patch points
+    patched = 0
+    errors = 0
+    doc_num = 0
+
+    for (firm_id, matter_id, document_id), points in groups.items():
+        doc_num += 1
+        doc_short = document_id[:8]
+        print(f"  [{doc_num}/{len(groups)}] doc={doc_short}  ({len(points)} chunk(s))...", end=" ", flush=True)
+
+        try:
+            chunks = fetch_chunks_json(s3, firm_id, matter_id, document_id)
+        except Exception as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            errors += len(points)
+            continue
+
+        # Build a lookup: chunk_index -> text
+        chunk_text: dict[int, str] = {c["chunk_index"]: c["text"] for c in chunks}
+
+        doc_patched = 0
+        for point in points:
+            p = point.payload or {}
+            idx = int(p.get("chunk_index", 0))
+            text = chunk_text.get(idx)
+
+            if text is None:
+                print(
+                    f"\n  WARNING: chunk_index {idx} not found in chunks.json for doc {doc_short}",
+                    file=sys.stderr,
+                )
+                errors += 1
+                continue
+
+            if not args.dry_run:
+                qdrant.set_payload(
+                    collection_name=COLLECTION,
+                    payload={"text": text},
+                    points=[point.id],
+                    timeout=60,
+                )
+
+            patched += 1
+            doc_patched += 1
+            # Inline progress for large documents
+            if doc_patched % 50 == 0:
+                print(f"{doc_patched}...", end=" ", flush=True)
+
+        print("done" if not args.dry_run else "dry-run")
+
+    # 5. Summary
+    print()
+    if args.dry_run:
+        print(f"Dry run complete. Would patch {patched} point(s).")
+    else:
+        print(f"Done. Patched {patched} point(s).")
+    if errors:
+        print(f"Errors: {errors} point(s) could not be patched — check stderr above.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_models.py
+++ b/scripts/eval_models.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Evaluate an exported RAG prompt against multiple Ollama models.
+
+Takes a prompt JSON file produced by ``scripts/rag_query.py --export-prompt``
+and runs the same assembled messages through each specified model.  With
+``--baseline``, each model is run twice — once with the full RAG context
+and once with the bare question (no retrieved documents) — so you can measure
+whether retrieval actually helps.
+
+Usage:
+    python scripts/eval_models.py prompt.json --models llama3,mistral
+
+    # RAG vs baseline comparison:
+    python scripts/eval_models.py prompt.json \\
+        --models llama3,mistral \\
+        --baseline \\
+        --output results.json
+
+    # Inspect the exported prompt without running inference:
+    python scripts/eval_models.py prompt.json --inspect
+
+Optional flags:
+    --models MODEL,...     Comma-separated Ollama model names to evaluate
+    --baseline             Also run each model without RAG context (bare question)
+    --output PATH          Write comparison results to JSON (default: none)
+    --max-tokens N         Max tokens per response (default: -2, fill context)
+    --inspect              Print the exported prompt and exit — no inference
+    --no-stream            Collect each full response before printing
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+OLLAMA_URL = "http://localhost:11434"
+DEFAULT_MAX_TOKENS = -2
+DEFAULT_MODELS = "llama3"
+
+
+# ---------------------------------------------------------------------------
+# Ollama helpers (urllib only — avoids WinError 10054 on localhost)
+# ---------------------------------------------------------------------------
+
+
+def _post_json(url: str, payload: dict, timeout: int = 30) -> dict:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def call_ollama_blocking(
+    model: str,
+    messages: list[dict],
+    max_tokens: int,
+) -> str:
+    result = _post_json(
+        f"{OLLAMA_URL}/api/chat",
+        {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "options": {"num_predict": max_tokens},
+        },
+        timeout=300,
+    )
+    return result["message"]["content"]
+
+
+def call_ollama_stream(
+    model: str,
+    messages: list[dict],
+    max_tokens: int,
+) -> str:
+    """Stream response from Ollama, print tokens as they arrive, return full text."""
+    payload = json.dumps({
+        "model": model,
+        "messages": messages,
+        "stream": True,
+        "options": {"num_predict": max_tokens},
+    }).encode()
+    req = urllib.request.Request(
+        f"{OLLAMA_URL}/api/chat",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    parts: list[str] = []
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        for raw_line in resp:
+            line = raw_line.decode().strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            token = data.get("message", {}).get("content", "")
+            if token:
+                print(token, end="", flush=True)
+                parts.append(token)
+            if data.get("done"):
+                break
+    print()
+    return "".join(parts)
+
+
+def _run(model: str, messages: list[dict], max_tokens: int, no_stream: bool) -> str:
+    """Run inference and return the full response text."""
+    try:
+        if no_stream:
+            return call_ollama_blocking(model, messages, max_tokens)
+        else:
+            return call_ollama_stream(model, messages, max_tokens)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return f"ERROR: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Prompt helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_baseline_messages(messages: list[dict]) -> list[dict]:
+    """Strip the RAG context block from the user message, leaving just the question.
+
+    The user message assembled by rag_query.py has the form:
+        "Context from case documents:\n\n<context>\n\nQuestion: <query>"
+
+    The baseline replaces that with just the bare question so the model must
+    answer from its own weights — no retrieved documents provided.
+    """
+    baseline = []
+    for msg in messages:
+        if msg.get("role") == "user":
+            content = msg["content"]
+            # Extract the question from "... \n\nQuestion: <query>"
+            marker = "\n\nQuestion: "
+            idx = content.rfind(marker)
+            bare_question = content[idx + len(marker):] if idx != -1 else content
+            baseline.append({"role": "user", "content": bare_question})
+        else:
+            baseline.append(msg)
+    return baseline
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate an exported RAG prompt against multiple Ollama models."
+    )
+    parser.add_argument(
+        "prompt_file",
+        metavar="PROMPT_FILE",
+        help="Path to a prompt JSON file produced by rag_query.py --export-prompt.",
+    )
+    parser.add_argument(
+        "--models",
+        default=DEFAULT_MODELS,
+        help=f"Comma-separated Ollama model names (default: {DEFAULT_MODELS}).",
+    )
+    parser.add_argument(
+        "--baseline",
+        action="store_true",
+        help=(
+            "Also run each model without RAG context (bare question only). "
+            "Lets you measure whether retrieval actually improves the answer."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="Write comparison results to JSON file.",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=DEFAULT_MAX_TOKENS,
+        help=f"Max tokens per response (default: {DEFAULT_MAX_TOKENS}, -2 = fill context).",
+    )
+    parser.add_argument(
+        "--inspect",
+        action="store_true",
+        help="Print the prompt contents and exit — no inference.",
+    )
+    parser.add_argument(
+        "--no-stream",
+        action="store_true",
+        help="Collect each full response before printing.",
+    )
+    return parser.parse_args()
+
+
+def _print_prompt(prompt: dict) -> None:
+    """Pretty-print the exported prompt for inspection."""
+    print("=" * 60)
+    print("PROMPT METADATA")
+    print("=" * 60)
+    print(f"  Query:      {prompt.get('query')}")
+    print(f"  Matter ID:  {prompt.get('matter_id')}")
+    print(f"  Firm ID:    {prompt.get('firm_id')}")
+    print(f"  Top-K:      {prompt.get('top_k')}")
+    excluded = prompt.get("excluded_classifications") or []
+    if excluded:
+        print(f"  Excluded:   {', '.join(excluded)}")
+
+    hits = prompt.get("retrieval_hits", [])
+    print(f"\n  Retrieved {len(hits)} chunk(s):")
+    for i, h in enumerate(hits, 1):
+        doc = str(h.get("document_id", ""))[:8]
+        score = h.get("score", 0)
+        chunk = h.get("chunk_index")
+        cls = h.get("classification")
+        bates = h.get("bates_number") or ""
+        page = h.get("page_number")
+        parts = [f"doc={doc}", f"chunk={chunk}", f"score={score:.4f}", f"class={cls}"]
+        if bates:
+            parts.append(f"bates={bates}")
+        if page is not None:
+            parts.append(f"page={page}")
+        print(f"    [{i}] {' | '.join(parts)}")
+
+    messages = prompt.get("messages", [])
+    print(f"\n  Messages ({len(messages)}):")
+    for msg in messages:
+        role = msg.get("role", "?")
+        content = msg.get("content", "")
+        preview = content[:200].replace("\n", " ")
+        ellipsis = "…" if len(content) > 200 else ""
+        print(f"\n  [{role.upper()}]\n  {preview}{ellipsis}")
+    print()
+
+
+def main() -> None:
+    args = parse_args()
+    prompt_path = Path(args.prompt_file)
+
+    if not prompt_path.exists():
+        print(f"ERROR: File not found: {prompt_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        prompt = json.loads(prompt_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"ERROR: Could not read prompt file: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    _print_prompt(prompt)
+
+    if args.inspect:
+        return
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    rag_messages = prompt.get("messages", [])
+    if not rag_messages:
+        print("ERROR: Prompt file contains no messages.", file=sys.stderr)
+        sys.exit(1)
+
+    baseline_messages = _build_baseline_messages(rag_messages) if args.baseline else None
+
+    mode_desc = "RAG + baseline" if args.baseline else "RAG only"
+    print(f"Running {mode_desc} against {len(models)} model(s): {', '.join(models)}\n")
+
+    results: list[dict] = []
+
+    for model in models:
+        result: dict = {"model": model}
+
+        # --- RAG response ---
+        print("=" * 60)
+        print(f"MODEL: {model}  |  WITH RAG CONTEXT")
+        print("=" * 60)
+        result["rag_response"] = _run(model, rag_messages, args.max_tokens, args.no_stream)
+        print()
+
+        # --- Baseline response (no context) ---
+        if baseline_messages is not None:
+            print("=" * 60)
+            print(f"MODEL: {model}  |  BASELINE (no context)")
+            print("=" * 60)
+            result["baseline_response"] = _run(
+                model, baseline_messages, args.max_tokens, args.no_stream
+            )
+            print()
+
+        results.append(result)
+
+    if args.output:
+        output_path = Path(args.output)
+        comparison = {
+            "prompt_file": str(prompt_path.resolve()),
+            "query": prompt.get("query"),
+            "matter_id": prompt.get("matter_id"),
+            "retrieval_hits": prompt.get("retrieval_hits", []),
+            "baseline_enabled": args.baseline,
+            "results": results,
+        }
+        output_path.write_text(
+            json.dumps(comparison, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        print(f"Results saved → {output_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/query_model.py
+++ b/scripts/query_model.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Query an Ollama model directly — no RAG, no Qdrant, no embedding.
+
+Sends the system prompt + a bare question to Ollama and streams the response.
+Use this as a baseline to compare against rag_query.py results, or to test
+model behaviour and system prompt changes in isolation.
+
+Usage:
+    python scripts/query_model.py "What Brady material exists for the defendant?"
+
+Optional flags:
+    --model MODEL          Ollama model name (default: llama3)
+    --system-prompt TEXT   Override the system prompt inline
+    --no-stream            Collect full response before printing
+    --max-tokens N         Max tokens to generate (default: -2, fill context)
+    --export PATH          Save the request + response to JSON
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+OLLAMA_URL = "http://localhost:11434"
+DEFAULT_MODEL = "llama3"
+DEFAULT_MAX_TOKENS = -2
+
+SYSTEM_PROMPT_PATH = Path("/app/SYSTEM_PROMPT.md")
+_DEFAULT_SYSTEM_PROMPT = (
+    "You are Gideon, a legal discovery assistant for criminal defense attorneys. "
+    "Answer questions based only on the documents retrieved for this matter. "
+    "If the answer is not in the provided context, say so clearly. "
+    "Always cite your sources."
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def load_system_prompt() -> str:
+    if SYSTEM_PROMPT_PATH.exists():
+        content = SYSTEM_PROMPT_PATH.read_text(encoding="utf-8").strip()
+        if content:
+            return content
+    return _DEFAULT_SYSTEM_PROMPT
+
+
+def _post_json(url: str, payload: dict, timeout: int = 30) -> dict:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def call_ollama_blocking(model: str, messages: list[dict], max_tokens: int) -> str:
+    result = _post_json(
+        f"{OLLAMA_URL}/api/chat",
+        {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "options": {"num_predict": max_tokens},
+        },
+        timeout=300,
+    )
+    return result["message"]["content"]
+
+
+def call_ollama_stream(model: str, messages: list[dict], max_tokens: int) -> str:
+    payload = json.dumps({
+        "model": model,
+        "messages": messages,
+        "stream": True,
+        "options": {"num_predict": max_tokens},
+    }).encode()
+    req = urllib.request.Request(
+        f"{OLLAMA_URL}/api/chat",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    parts: list[str] = []
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        for raw_line in resp:
+            line = raw_line.decode().strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            token = data.get("message", {}).get("content", "")
+            if token:
+                print(token, end="", flush=True)
+                parts.append(token)
+            if data.get("done"):
+                break
+    print()
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Query an Ollama model directly — no RAG context."
+    )
+    parser.add_argument("query", nargs="+", help="The question to ask.")
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Ollama model name (default: {DEFAULT_MODEL}).",
+    )
+    parser.add_argument(
+        "--system-prompt",
+        default=None,
+        metavar="TEXT",
+        help="Override the system prompt inline (default: load from SYSTEM_PROMPT.md).",
+    )
+    parser.add_argument(
+        "--no-stream",
+        action="store_true",
+        help="Collect full response before printing.",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=DEFAULT_MAX_TOKENS,
+        help=f"Max tokens to generate (default: {DEFAULT_MAX_TOKENS}, -2 = fill context).",
+    )
+    parser.add_argument(
+        "--export",
+        metavar="PATH",
+        default=None,
+        help="Save the request and response to a JSON file.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    query = " ".join(args.query)
+    system_prompt = args.system_prompt or load_system_prompt()
+
+    print(f'Query:  "{query}"')
+    print(f"Model:  {args.model}")
+    print(f"Mode:   direct (no RAG context)")
+    print()
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": query},
+    ]
+
+    print("=" * 60)
+    print("RESPONSE")
+    print("=" * 60)
+
+    try:
+        if args.no_stream:
+            response = call_ollama_blocking(args.model, messages, args.max_tokens)
+            print(response)
+        else:
+            response = call_ollama_stream(args.model, messages, args.max_tokens)
+    except Exception as exc:
+        print(f"\nERROR: Ollama inference failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.export:
+        export_path = Path(args.export)
+        export_path.write_text(
+            json.dumps(
+                {
+                    "query": query,
+                    "model": args.model,
+                    "mode": "direct",
+                    "messages": messages,
+                    "response": response,
+                },
+                indent=2,
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        print(f"\nExported → {export_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rag_query.py
+++ b/scripts/rag_query.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""End-to-end RAG query against the Gideon stack.
+
+Runs inside the FastAPI container so it can reach Ollama and Qdrant
+on the Docker network.  Embeds a query, searches Qdrant (with an
+optional classification exclusion filter), prints the retrieved context
+block, then calls Ollama for inference and streams the response.
+
+Usage (from repo root):
+    docker exec gideon-fastapi-1 python scripts/rag_query.py \\
+        --matter-id <uuid> \\
+        --firm-id <uuid> \\
+        "What Brady material exists for the defendant?"
+
+Optional flags:
+    --top-k N              Number of chunks to retrieve (default: 5)
+    --model MODEL          Ollama model name (default: llama3)
+    --exclude CLASS,...    Comma-separated classifications to exclude
+                           e.g. --exclude jencks,work_product
+    --no-stream            Collect full response before printing
+    --export-prompt PATH   Save assembled messages to JSON (before inference)
+    --no-infer             Stop after prompt assembly — no Ollama call
+
+The --export-prompt JSON can be passed to scripts/eval_models.py to run
+the same prompt against multiple models for evaluation.
+
+Note: This script bypasses the FastAPI auth layer and build_qdrant_filter.
+It is a developer tool only — never expose it in production.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+import httpx
+from qdrant_client import QdrantClient, models
+from qdrant_client.models import FieldCondition, MatchAny, MatchValue
+
+# ---------------------------------------------------------------------------
+# Constants — mirror defaults from app/core/config.py
+# ---------------------------------------------------------------------------
+
+OLLAMA_URL = "http://localhost:11434"
+QDRANT_URL = "http://localhost:6333"
+COLLECTION = "gideon"
+EMBEDDING_MODEL = "nomic-embed-text"
+DEFAULT_MODEL = "llama3"
+DEFAULT_TOP_K = 5
+# -2 = fill context window; matches Ollama behaviour when no limit is wanted.
+# Override with --max-tokens if you want a hard cap.
+DEFAULT_MAX_TOKENS = -2
+
+SYSTEM_PROMPT_PATH = Path("./backend/SYSTEM_PROMPT.md")
+_DEFAULT_SYSTEM_PROMPT = (
+    "You are Gideon, a legal discovery assistant for criminal defense attorneys. "
+    "Answer questions based only on the documents retrieved for this matter. "
+    "If the answer is not in the provided context, say so clearly. "
+    "Always cite your sources."
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def load_system_prompt() -> str:
+    if SYSTEM_PROMPT_PATH.exists():
+        content = SYSTEM_PROMPT_PATH.read_text(encoding="utf-8").strip()
+        if content:
+            return content
+    return _DEFAULT_SYSTEM_PROMPT
+
+
+def _post_json(url: str, payload: dict, timeout: int = 30) -> dict:
+    """POST JSON via stdlib urllib — avoids httpx WinError 10054 on localhost."""
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def embed_query(query: str) -> list[float]:
+    result = _post_json(
+        f"{OLLAMA_URL}/api/embed",
+        {"model": EMBEDDING_MODEL, "input": [query]},
+    )
+    return result["embeddings"][0]
+
+
+def build_filter(
+    firm_id: str,
+    matter_id: str,
+    excluded_classifications: list[str],
+) -> models.Filter:
+    must = [
+        FieldCondition(key="firm_id", match=MatchValue(value=firm_id)),
+        FieldCondition(key="matter_id", match=MatchAny(any=[matter_id])),
+    ]
+    must_not: list[FieldCondition] = []
+    if excluded_classifications:
+        must_not = [
+            FieldCondition(
+                key="classification",
+                match=MatchAny(any=excluded_classifications),
+            )
+        ]
+    return models.Filter(must=must, must_not=must_not)
+
+
+def search_qdrant(
+    client: QdrantClient,
+    vector: list[float],
+    qdrant_filter: models.Filter,
+    limit: int,
+) -> list[models.ScoredPoint]:
+    result = client.query_points(
+        collection_name=COLLECTION,
+        query=vector,
+        query_filter=qdrant_filter,
+        limit=limit,
+        with_payload=True,
+    )
+    return result.points
+
+
+def format_context(chunks: list[models.ScoredPoint]) -> str:
+    if not chunks:
+        return "No relevant documents were found for this query."
+    parts: list[str] = []
+    for i, point in enumerate(chunks, 1):
+        p = point.payload or {}
+        doc_id = str(p.get("document_id", ""))[:8]
+        page = p.get("page_number")
+        bates = p.get("bates_number")
+        # Text is stored directly in the Qdrant payload (Feature 7.3+).
+        # Older points without 'text' fall back to a placeholder.
+        text = str(p.get("text") or "(chunk text not in payload — re-ingest document)")
+
+        header_parts = [f"Source {i}", f"Doc: {doc_id}"]
+        if page is not None:
+            header_parts.append(f"Page: {page}")
+        if bates:
+            header_parts.append(f"Bates: {bates}")
+
+        parts.append(f"[{' | '.join(header_parts)}]\n{text}")
+    return "\n\n".join(parts)
+
+
+def call_ollama_stream(
+    model: str,
+    system_prompt: str,
+    context: str,
+    query: str,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+) -> None:
+    """Call Ollama /api/chat with streaming and print tokens as they arrive."""
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {
+            "role": "user",
+            "content": f"Context from case documents:\n\n{context}\n\nQuestion: {query}",
+        },
+    ]
+    payload = json.dumps({
+        "model": model,
+        "messages": messages,
+        "stream": True,
+        "options": {"num_predict": max_tokens},
+    }).encode()
+    req = urllib.request.Request(
+        f"{OLLAMA_URL}/api/chat",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        for raw_line in resp:
+            line = raw_line.decode().strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            token = data.get("message", {}).get("content", "")
+            if token:
+                print(token, end="", flush=True)
+            if data.get("done"):
+                break
+    print()  # final newline
+
+
+def call_ollama_blocking(
+    model: str,
+    system_prompt: str,
+    context: str,
+    query: str,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+) -> str:
+    """Call Ollama /api/chat without streaming. Returns full response."""
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {
+            "role": "user",
+            "content": f"Context from case documents:\n\n{context}\n\nQuestion: {query}",
+        },
+    ]
+    result = _post_json(
+        f"{OLLAMA_URL}/api/chat",
+        {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "options": {"num_predict": max_tokens},
+        },
+        timeout=120,
+    )
+    return result["message"]["content"]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="RAG query against the Gideon stack (dev/debug tool)."
+    )
+    parser.add_argument("query", nargs="+", help="The query text.")
+    parser.add_argument("--matter-id", required=True, help="Matter UUID to query.")
+    parser.add_argument("--firm-id", required=True, help="Firm UUID to filter by.")
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=DEFAULT_TOP_K,
+        help=f"Number of chunks to retrieve (default: {DEFAULT_TOP_K}).",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Ollama model name (default: {DEFAULT_MODEL}).",
+    )
+    parser.add_argument(
+        "--exclude",
+        default="",
+        help="Comma-separated classifications to exclude (e.g. jencks,work_product).",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=DEFAULT_MAX_TOKENS,
+        help=(
+            f"Max tokens to generate (default: {DEFAULT_MAX_TOKENS}, "
+            "-2 = fill context, -1 = infinite)."
+        ),
+    )
+    parser.add_argument(
+        "--no-stream",
+        action="store_true",
+        help="Collect full response before printing (useful for piping).",
+    )
+    parser.add_argument(
+        "--export-prompt",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Save the fully assembled messages (system + context + query) to a JSON "
+            "file before calling Ollama. Pass this file to scripts/eval_models.py "
+            "to benchmark the same prompt against multiple models."
+        ),
+    )
+    parser.add_argument(
+        "--no-infer",
+        action="store_true",
+        help="Stop after prompt assembly — skip the Ollama call entirely. "
+             "Useful with --export-prompt to inspect prompts for private data.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    query = " ".join(args.query)
+    excluded = [c.strip() for c in args.exclude.split(",") if c.strip()]
+
+    print(f'Query:     "{query}"')
+    print(f"Matter ID: {args.matter_id}")
+    print(f"Firm ID:   {args.firm_id}")
+    print(f"Top-K:     {args.top_k}")
+    print(f"Model:     {args.model}")
+    if excluded:
+        print(f"Excluded:  {', '.join(excluded)}")
+    if args.export_prompt:
+        print(f"Export:    {args.export_prompt}")
+    if args.no_infer:
+        print("Mode:      prompt assembly only — no inference")
+    print()
+
+    # 1. Embed query
+    print("Embedding query...", flush=True)
+    try:
+        vector = embed_query(query)
+    except Exception as exc:
+        print(f"ERROR: Failed to embed query: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # 2. Build filter and search Qdrant
+    print("Searching Qdrant...", flush=True)
+    try:
+        client = QdrantClient(
+            url=QDRANT_URL,
+            timeout=60,
+            # Disable keep-alive pooling to avoid WinError 10054 on Windows
+            limits=httpx.Limits(max_keepalive_connections=0, max_connections=10),
+        )
+        qdrant_filter = build_filter(args.firm_id, args.matter_id, excluded)
+        hits = search_qdrant(client, vector, qdrant_filter, args.top_k)
+    except Exception as exc:
+        print(f"ERROR: Qdrant search failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Retrieved {len(hits)} chunk(s).\n")
+
+    # 3. Print retrieved context so developer can see what the model receives
+    context = format_context(hits)
+    print("=" * 60)
+    print("RETRIEVED CONTEXT")
+    print("=" * 60)
+    print(context)
+    print()
+
+    # 4. Print each result's metadata summary
+    for i, hit in enumerate(hits, 1):
+        p = hit.payload or {}
+        print(
+            f"  [{i}] score={hit.score:.4f} | doc={str(p.get('document_id', ''))[:8]}"
+            f" | chunk={p.get('chunk_index')} | class={p.get('classification')}"
+        )
+    print()
+
+    # 5. Assemble prompt
+    system_prompt = load_system_prompt()
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {
+            "role": "user",
+            "content": f"Context from case documents:\n\n{context}\n\nQuestion: {query}",
+        },
+    ]
+
+    # 5a. Export prompt JSON if requested
+    if args.export_prompt:
+        export_path = Path(args.export_prompt)
+        prompt_export = {
+            "query": query,
+            "matter_id": args.matter_id,
+            "firm_id": args.firm_id,
+            "top_k": args.top_k,
+            "excluded_classifications": excluded,
+            "retrieval_hits": [
+                {
+                    "score": round(h.score, 6),
+                    "document_id": str((h.payload or {}).get("document_id", "")),
+                    "chunk_index": (h.payload or {}).get("chunk_index"),
+                    "classification": (h.payload or {}).get("classification"),
+                    "bates_number": (h.payload or {}).get("bates_number"),
+                    "page_number": (h.payload or {}).get("page_number"),
+                }
+                for h in hits
+            ],
+            "messages": messages,
+        }
+        export_path.write_text(json.dumps(prompt_export, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"\nPrompt exported → {export_path.resolve()}")
+
+    if args.no_infer:
+        return
+
+    # 5b. Run inference
+    print("=" * 60)
+    print("LLM RESPONSE")
+    print("=" * 60)
+    try:
+        if args.no_stream:
+            response = call_ollama_blocking(args.model, system_prompt, context, query, args.max_tokens)
+            print(response)
+        else:
+            call_ollama_stream(args.model, system_prompt, context, query, args.max_tokens)
+    except Exception as exc:
+        print(f"\nERROR: Ollama inference failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Wires `/chats` and `/chats/stream` to a full RAG pipeline: embed → permission-filtered Qdrant search → prompt assembly → Ollama inference → DB persist
- Adds `QdrantVectorStore.search()` with OTel metrics and stores chunk `text` in Qdrant payload so retrieval is self-contained (no MinIO round-trip at query time)
- SSE stream yields `data: {"error": "..."}` + `data: [DONE]` on mid-stream failure; span lifetime now covers the full generator, not just setup
- Restores work-product and Jencks rules to `SYSTEM_PROMPT.md` (defence-in-depth against misclassified documents)
- `ADDITIONAL_MODELS` env var lets operators pre-pull eval models into the `ollama-models` volume at startup
- Dev scripts: `rag_query.py` (end-to-end RAG harness), `eval_models.py`, `query_model.py`, `backfill_chunk_text.py` (patches pre-7.3 Qdrant points that lack the `text` payload field)

## Security

`build_qdrant_filter` is called first in both `run_query` and `stream_query` before any vector search. `test_build_qdrant_filter_called_before_search` asserts the call ordering explicitly.

## Test plan

- [ ] `pytest backend/tests/test_rag_pipeline.py` — pipeline unit tests (all mocked, no services needed)
- [ ] `pytest backend/tests/test_chats.py` — endpoint tests including mid-stream error frame assertion
- [ ] `pytest backend/tests/test_vectorstore.py` — VectorPayload schema check updated for `text` field
- [ ] End-to-end: `docker exec gideon-fastapi-1 python scripts/rag_query.py --matter-id <uuid> --firm-id <uuid> "What Brady material exists?"`

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)