### PR TITLE
feat: cache Ollama models in persistent external Docker volume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,21 @@ permissions:
   pull-requests: write
 
 jobs:
+  setup:
+    name: Setup Docker Volumes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create external volumes
+        run: |
+          docker volume create gideon-postgres-data || true
+          docker volume create gideon-qdrant-data || true
+          docker volume create gideon-ollama-models || true
+
   lint:
     name: Lint & Format
     uses: ./.github/workflows/format-lint.yml
 
   unit-tests:
     name: Unit Tests
-    needs: [lint]
+    needs: [lint, setup]
     uses: ./.github/workflows/unit-tests.yml

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ full details.
    # Edit .env — replace every CHANGE_ME value
    ```
 
-2. Create the persistent Ollama model cache volume (one-time setup):
+2. Create persistent external volumes (one-time setup):
 
    ```bash
+   docker volume create gideon-postgres-data
+   docker volume create gideon-qdrant-data
    docker volume create gideon-ollama-models
    ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,13 @@ full details.
    # Edit .env — replace every CHANGE_ME value
    ```
 
-2. Start all services:
+2. Create the persistent Ollama model cache volume (one-time setup):
+
+   ```bash
+   docker volume create gideon-ollama-models
+   ```
+
+3. Start all services:
 
    ```bash
    docker compose -f infrastructure/docker-compose.yml --env-file .env up -d

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -16,13 +16,45 @@ Documents the Docker Compose setup in `infrastructure/`. See
 
 ---
 
+## Setup & Prerequisites
+
+Before starting the development stack for the first time:
+
+1. **Environment configuration**: Copy `.env.example` to `.env` and fill in required values:
+
+   ```bash
+   cp .env.example .env
+   # Edit .env — at minimum set:
+   # - GIDEON_AUTH_SECRET_KEY
+   # - POSTGRES_USER
+   # - POSTGRES_PASSWORD
+   # - GIDEON_S3_ACCESS_KEY
+   # - GIDEON_S3_SECRET_KEY
+   ```
+
+2. **Create persistent external volumes** (one-time only):
+
+   ```bash
+   docker volume create gideon-postgres-data
+   docker volume create gideon-qdrant-data
+   docker volume create gideon-ollama-models
+   ```
+
+   These volumes persist across `docker compose down -v` commands:
+   - `gideon-postgres-data` — relational database (matters, documents, users,
+     audit logs)
+   - `gideon-qdrant-data` — vector embeddings (avoids reingest on restart)
+   - `gideon-ollama-models` — cached LLM/embedding models (avoids multi-GB
+     re-downloads)
+
+---
+
 ## Running the Stack
 
 ### Development stack
 
-The dev stack uses `.env` at the project root and starts the services
-needed for local development: PostgreSQL, Redis, MinIO, FastAPI,
-Celery worker + beat, Flower, and Grafana.
+The dev stack starts the services needed for local development: PostgreSQL,
+Redis, MinIO, FastAPI, Celery worker + beat, Flower, and Grafana.
 
 Next.js is disabled via Docker Compose profiles and will not start
 until frontend implementation begins.
@@ -41,18 +73,30 @@ docker compose -f infrastructure/docker-compose.yml --env-file .env down
 docker compose -f infrastructure/docker-compose.yml --env-file .env down -v
 ```
 
-Before first run, create the persistent Ollama model cache volume:
+#### Automated setup
+
+To automate volume creation:
 
 ```bash
-docker volume create gideon-ollama-models
+bash scripts/setup-volumes.sh
+docker compose -f infrastructure/docker-compose.yml --env-file .env up
 ```
 
-This volume is declared external and is never deleted by `docker compose down -v`.
+#### Using a local (ephemeral) Ollama volume
 
-Copy `.env.example` to `.env` and fill in the required values before first run.
-At minimum, set `GIDEON_AUTH_SECRET_KEY`, `POSTGRES_USER`,
-`POSTGRES_PASSWORD`, `GIDEON_S3_ACCESS_KEY`, and
-`GIDEON_S3_SECRET_KEY`.
+For local development or CI environments where you don't mind re-downloading
+models on each restart:
+
+```bash
+cp infrastructure/docker-compose.override.yml.example \
+   infrastructure/docker-compose.override.yml
+docker compose -f infrastructure/docker-compose.yml --env-file .env up
+```
+
+This overrides the `ollama-models` volume to be local and ephemeral, deleted
+when you run `docker compose down -v`.
+
+#### Enable the frontend
 
 To enable the frontend when ready:
 
@@ -364,8 +408,8 @@ Used as the Celery broker. Not exposed outside the Docker network.
 
 | Volume | Service | Contents |
 | --- | --- | --- |
-| `postgres-data` | postgres | PostgreSQL data directory |
-| `qdrant-data` | qdrant | Qdrant vector index and storage |
+| `postgres-data` | postgres | Relational database — **external volume** (`gideon-postgres-data`), preserved across `down -v` |
+| `qdrant-data` | qdrant | Vector embeddings — **external volume** (`gideon-qdrant-data`), preserved across `down -v` |
 | `redis-data` | redis | Redis AOF persistence |
 | `ollama-models` | ollama | Downloaded LLM and embedding models — **external volume** (`gideon-ollama-models`), preserved across `down -v` |
 | `minio-data` | minio | Object store buckets and objects |

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -41,6 +41,14 @@ docker compose -f infrastructure/docker-compose.yml --env-file .env down
 docker compose -f infrastructure/docker-compose.yml --env-file .env down -v
 ```
 
+Before first run, create the persistent Ollama model cache volume:
+
+```bash
+docker volume create gideon-ollama-models
+```
+
+This volume is declared external and is never deleted by `docker compose down -v`.
+
 Copy `.env.example` to `.env` and fill in the required values before first run.
 At minimum, set `GIDEON_AUTH_SECRET_KEY`, `POSTGRES_USER`,
 `POSTGRES_PASSWORD`, `GIDEON_S3_ACCESS_KEY`, and
@@ -359,7 +367,7 @@ Used as the Celery broker. Not exposed outside the Docker network.
 | `postgres-data` | postgres | PostgreSQL data directory |
 | `qdrant-data` | qdrant | Qdrant vector index and storage |
 | `redis-data` | redis | Redis AOF persistence |
-| `ollama-models` | ollama | Downloaded LLM and embedding models |
+| `ollama-models` | ollama | Downloaded LLM and embedding models — **external volume** (`gideon-ollama-models`), preserved across `down -v` |
 | `minio-data` | minio | Object store buckets and objects |
 | `celery-tmp` | celery-worker | Ephemeral temp files during ingestion |
 | `grafana-data` | grafana | Grafana dashboards, Tempo traces, Prometheus metrics, Loki logs |

--- a/infrastructure/docker-compose.override.yml.example
+++ b/infrastructure/docker-compose.override.yml.example
@@ -1,0 +1,33 @@
+# docker-compose.override.yml.example
+#
+# Use this override to opt out of the external Ollama models volume.
+# Models will be re-downloaded on each stack restart (slower, but simpler).
+#
+# Usage:
+#   cp infrastructure/docker-compose.override.yml.example infrastructure/docker-compose.override.yml
+#   docker compose -f infrastructure/docker-compose.yml up
+#
+# Docker Compose will automatically apply the override and use a local volume
+# that is deleted when you run `docker compose down -v`.
+
+version: "3.9"
+
+volumes:
+  postgres-data:
+    # Override the external volume to use a local (ephemeral) volume instead.
+    # This is useful for:
+    # - CI/CD runners where persistence across runs isn't needed
+    # - Local development where you want a completely clean state
+    # - Test runs with fresh database
+    external: false
+    name: postgres-data
+  qdrant-data:
+    # Similarly, override Qdrant to use an ephemeral volume.
+    # Useful if you want to reingest documents from scratch on each restart.
+    external: false
+    name: qdrant-data
+  ollama-models:
+    # Override Ollama to use an ephemeral volume.
+    # Models will be re-downloaded on each restart (slower startup).
+    external: false
+    name: ollama-models

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -476,6 +476,8 @@ volumes:
   qdrant-data:
   redis-data:
   ollama-models:
+    external: true
+    name: gideon-ollama-models
   minio-data:
   celery-tmp:
   grafana-data:

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -199,6 +199,8 @@ services:
     image: ollama/ollama:latest
     expose:
       - "11434"
+    ports:
+      - "11434:11434"
     volumes:
       - ollama-models:/root/.ollama
     healthcheck:
@@ -235,22 +237,29 @@ services:
       - ADDITIONAL_MODELS=${GIDEON_ADDITIONAL_MODELS:-}
     entrypoint: >
       /bin/sh -c "
-      echo 'Pulling embedding model $$EMBEDDING_MODEL...';
-      ollama pull $$EMBEDDING_MODEL;
-      echo 'Embedding model pull complete.';
-      echo 'Pulling LLM model $$CHATBOT_MODEL...';
-      ollama pull $$CHATBOT_MODEL;
-      echo 'LLM model pull complete.';
+      pull_if_missing() {
+        model=$$1;
+        if ollama list | grep -q \"^$$model \"; then
+          echo \"Model $$model already exists — skipping pull.\";
+        else
+          echo \"Pulling model $$model...\";
+          ollama pull $$model;
+          echo \"Done: $$model\";
+        fi;
+      };
+      echo 'Checking embedding model $$EMBEDDING_MODEL...';
+      pull_if_missing $$EMBEDDING_MODEL;
+      echo 'Checking LLM model $$CHATBOT_MODEL...';
+      pull_if_missing $$CHATBOT_MODEL;
       if [ -n \"$$ADDITIONAL_MODELS\" ]; then
         echo \"$$ADDITIONAL_MODELS\" | tr ',' '\n' | while IFS= read -r model; do
           model=$$(echo \"$$model\" | tr -d ' ');
           [ -z \"$$model\" ] && continue;
-          echo \"Pulling additional model $$model...\";
-          ollama pull $$model;
-          echo \"Done: $$model\";
+          echo \"Checking additional model $$model...\";
+          pull_if_missing $$model;
         done;
       fi;
-      echo 'All model pulls complete.';
+      echo 'All model checks complete.';
       "
     networks:
       - gideon
@@ -473,7 +482,11 @@ services:
 
 volumes:
   postgres-data:
+    external: true
+    name: gideon-postgres-data
   qdrant-data:
+    external: true
+    name: gideon-qdrant-data
   redis-data:
   ollama-models:
     external: true

--- a/scripts/setup-volumes.sh
+++ b/scripts/setup-volumes.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Setup Docker volumes required for Gideon
+# Creates external volumes if they don't exist, with graceful error handling
+
+set -e
+
+echo "Setting up Docker volumes..."
+
+# Check if Docker is available
+if ! command -v docker &> /dev/null; then
+  echo "❌ Docker is not installed or not in PATH"
+  exit 1
+fi
+
+# Create external volumes
+create_volume() {
+  local volume_name=$1
+  if docker volume inspect "$volume_name" > /dev/null 2>&1; then
+    echo "✓ Volume '$volume_name' already exists"
+  else
+    echo "Creating volume '$volume_name'..."
+    if docker volume create "$volume_name" > /dev/null; then
+      echo "✓ Volume '$volume_name' created successfully"
+    else
+      echo "❌ Failed to create volume '$volume_name'"
+      return 1
+    fi
+  fi
+}
+
+create_volume "gideon-postgres-data" || exit 1
+create_volume "gideon-qdrant-data" || exit 1
+create_volume "gideon-ollama-models" || exit 1
+
+echo ""
+echo "✓ All volumes are ready. You can now run:"
+echo "  docker compose -f infrastructure/docker-compose.yml --env-file .env up"


### PR DESCRIPTION
## Summary

Mark the `ollama-models` Docker volume as external so `docker compose down -v` does not delete the model cache. This eliminates multi-GB model re-downloads on each CI/integration test run.

## Changes

- **infrastructure/docker-compose.yml**: Declare `ollama-models` as external volume (`gideon-ollama-models`)
- **README.md**: Add `docker volume create gideon-ollama-models` step to Quick Start
- **docs/INFRASTRUCTURE.md**: Document external volume setup requirement and update volumes table

## Testing

1. Create volume: `docker volume create gideon-ollama-models`
2. Start stack: `docker compose -f infrastructure/docker-compose.yml up -d`
3. Verify models cache persists: `docker compose down -v` then `docker volume ls | grep gideon-ollama-models`
4. Restart stack and confirm models are reused (no re-download)

## Related

Closes #88