### PR TITLE
fix(#92): Resolve Clean Code violations in /scripts folder

### DIFF
--- a/scripts/_ollama.py
+++ b/scripts/_ollama.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Shared Ollama HTTP helpers for scripts.
+
+Provides low-level functions for calling Ollama's /api/chat endpoint.
+Used by eval_models.py, query_model.py, and rag_query.py.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+
+OLLAMA_URL = "http://localhost:11434"
+
+
+def _post_json(url: str, payload: dict, timeout: int = 30) -> dict:
+    """POST JSON to a URL and return the parsed response."""
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def call_ollama_blocking(
+    model: str,
+    messages: list[dict],
+    max_tokens: int,
+    timeout: int = 300,
+) -> str:
+    """Call Ollama /api/chat without streaming. Returns full response."""
+    result = _post_json(
+        f"{OLLAMA_URL}/api/chat",
+        {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "options": {"num_predict": max_tokens},
+        },
+        timeout=timeout,
+    )
+    return result["message"]["content"]
+
+
+def call_ollama_stream(
+    model: str,
+    messages: list[dict],
+    max_tokens: int,
+    timeout: int = 300,
+) -> str:
+    """Stream response from Ollama, print tokens as they arrive, return full text."""
+    payload = json.dumps({
+        "model": model,
+        "messages": messages,
+        "stream": True,
+        "options": {"num_predict": max_tokens},
+    }).encode()
+    req = urllib.request.Request(
+        f"{OLLAMA_URL}/api/chat",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    parts: list[str] = []
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        for raw_line in resp:
+            line = raw_line.decode().strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            token = data.get("message", {}).get("content", "")
+            if token:
+                print(token, end="", flush=True)
+                parts.append(token)
+            if data.get("done"):
+                break
+    print()
+    return "".join(parts)

--- a/scripts/eval_models.py
+++ b/scripts/eval_models.py
@@ -33,85 +33,16 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import urllib.request
 from pathlib import Path
+
+from _ollama import OLLAMA_URL, call_ollama_blocking, call_ollama_stream
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-OLLAMA_URL = "http://localhost:11434"
 DEFAULT_MAX_TOKENS = -2
 DEFAULT_MODELS = "llama3"
-
-
-# ---------------------------------------------------------------------------
-# Ollama helpers (urllib only — avoids WinError 10054 on localhost)
-# ---------------------------------------------------------------------------
-
-
-def _post_json(url: str, payload: dict, timeout: int = 30) -> dict:
-    data = json.dumps(payload).encode()
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}
-    )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read())
-
-
-def call_ollama_blocking(
-    model: str,
-    messages: list[dict],
-    max_tokens: int,
-) -> str:
-    result = _post_json(
-        f"{OLLAMA_URL}/api/chat",
-        {
-            "model": model,
-            "messages": messages,
-            "stream": False,
-            "options": {"num_predict": max_tokens},
-        },
-        timeout=300,
-    )
-    return result["message"]["content"]
-
-
-def call_ollama_stream(
-    model: str,
-    messages: list[dict],
-    max_tokens: int,
-) -> str:
-    """Stream response from Ollama, print tokens as they arrive, return full text."""
-    payload = json.dumps({
-        "model": model,
-        "messages": messages,
-        "stream": True,
-        "options": {"num_predict": max_tokens},
-    }).encode()
-    req = urllib.request.Request(
-        f"{OLLAMA_URL}/api/chat",
-        data=payload,
-        headers={"Content-Type": "application/json"},
-    )
-    parts: list[str] = []
-    with urllib.request.urlopen(req, timeout=300) as resp:
-        for raw_line in resp:
-            line = raw_line.decode().strip()
-            if not line:
-                continue
-            try:
-                data = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            token = data.get("message", {}).get("content", "")
-            if token:
-                print(token, end="", flush=True)
-                parts.append(token)
-            if data.get("done"):
-                break
-    print()
-    return "".join(parts)
 
 
 def _run(model: str, messages: list[dict], max_tokens: int, no_stream: bool) -> str:

--- a/scripts/query_model.py
+++ b/scripts/query_model.py
@@ -21,14 +21,14 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import urllib.request
 from pathlib import Path
+
+from _ollama import OLLAMA_URL, call_ollama_blocking, call_ollama_stream
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-OLLAMA_URL = "http://localhost:11434"
 DEFAULT_MODEL = "llama3"
 DEFAULT_MAX_TOKENS = -2
 
@@ -52,61 +52,6 @@ def load_system_prompt() -> str:
         if content:
             return content
     return _DEFAULT_SYSTEM_PROMPT
-
-
-def _post_json(url: str, payload: dict, timeout: int = 30) -> dict:
-    data = json.dumps(payload).encode()
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}
-    )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read())
-
-
-def call_ollama_blocking(model: str, messages: list[dict], max_tokens: int) -> str:
-    result = _post_json(
-        f"{OLLAMA_URL}/api/chat",
-        {
-            "model": model,
-            "messages": messages,
-            "stream": False,
-            "options": {"num_predict": max_tokens},
-        },
-        timeout=300,
-    )
-    return result["message"]["content"]
-
-
-def call_ollama_stream(model: str, messages: list[dict], max_tokens: int) -> str:
-    payload = json.dumps({
-        "model": model,
-        "messages": messages,
-        "stream": True,
-        "options": {"num_predict": max_tokens},
-    }).encode()
-    req = urllib.request.Request(
-        f"{OLLAMA_URL}/api/chat",
-        data=payload,
-        headers={"Content-Type": "application/json"},
-    )
-    parts: list[str] = []
-    with urllib.request.urlopen(req, timeout=300) as resp:
-        for raw_line in resp:
-            line = raw_line.decode().strip()
-            if not line:
-                continue
-            try:
-                data = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            token = data.get("message", {}).get("content", "")
-            if token:
-                print(token, end="", flush=True)
-                parts.append(token)
-            if data.get("done"):
-                break
-    print()
-    return "".join(parts)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/rag_query.py
+++ b/scripts/rag_query.py
@@ -40,11 +40,12 @@ import httpx
 from qdrant_client import QdrantClient, models
 from qdrant_client.models import FieldCondition, MatchAny, MatchValue
 
+from _ollama import OLLAMA_URL, _post_json
+
 # ---------------------------------------------------------------------------
 # Constants — mirror defaults from app/core/config.py
 # ---------------------------------------------------------------------------
 
-OLLAMA_URL = "http://localhost:11434"
 QDRANT_URL = "http://localhost:6333"
 COLLECTION = "gideon"
 EMBEDDING_MODEL = "nomic-embed-text"
@@ -74,16 +75,6 @@ def load_system_prompt() -> str:
         if content:
             return content
     return _DEFAULT_SYSTEM_PROMPT
-
-
-def _post_json(url: str, payload: dict, timeout: int = 30) -> dict:
-    """POST JSON via stdlib urllib — avoids httpx WinError 10054 on localhost."""
-    data = json.dumps(payload).encode()
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}
-    )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read())
 
 
 def embed_query(query: str) -> list[float]:

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 
 import argparse
 import sys
+import uuid
 
 import dotenv
 from gideon import Client
 from gideon.exceptions import GideonError, ValidationError
 
 BASE_URL = "http://127.0.0.1:8000"
+HTTP_CONFLICT = 409
 DEMO_PASSWORD = "DemoPassword123!"  # noqa: S105
 
 
@@ -47,7 +49,7 @@ def _create_user(
         print(f"  Created user: {first_name} {last_name} <{email}> ({role})")  # noqa: T201
         return str(user.id)
     except (GideonError, ValidationError) as exc:
-        if "already" in str(exc).lower() or getattr(exc, "status_code", 0) == 409:  # noqa: PLR2004
+        if "already" in str(exc).lower() or getattr(exc, "status_code", 0) == HTTP_CONFLICT:
             # User exists — find them
             users = client.list_users()
             for u in users:
@@ -59,8 +61,6 @@ def _create_user(
 
 def _create_matter(client: Client, name: str) -> str:
     """Create a matter, return matter_id.  Skip if already exists."""
-    import uuid
-
     matters = client.list_matters()
     for m in matters:
         if m.name == name:

--- a/scripts/submit_task.py
+++ b/scripts/submit_task.py
@@ -4,7 +4,7 @@ from gideon import Client
 
 BASE_URL = "http://127.0.0.1:8000"
 
-def submit_log_running_task(client: Client) -> None:
+def submit_long_running_task(client: Client) -> None:
     print("Submitting long-running task (sleep for 30 seconds)...")
     result = client.submit_task(task_name="sleep", kwargs={"seconds": 30})
     print(f"Submitted: {result.task_id}")
@@ -39,7 +39,7 @@ def main(config_file: str) -> None:
 
         client.login(email=admin_email, password=admin_password)
 
-        submit_log_running_task(client)
+        submit_long_running_task(client)
 
         ping_result = submit_ping_task(client)
         wait_for_task_result(client, ping_result.task_id)

--- a/scripts/upload_file.py
+++ b/scripts/upload_file.py
@@ -127,7 +127,7 @@ def verify_download(client: Client, doc_id: str, local_hash: str) -> None:
     print("\nVerifying download (GET /documents/{id}/download)...")  # noqa: T201
     resp = httpx.get(
         f"{BASE_URL}/documents/{doc_id}/download",
-        headers=client._auth.authorization_header,  # noqa: SLF001
+        headers=client.authorization_header,
         timeout=30,
     )
     if resp.status_code != 200:  # noqa: PLR2004

--- a/sdk/gideon/client.py
+++ b/sdk/gideon/client.py
@@ -99,6 +99,15 @@ class Client:
         """Close the underlying HTTP connection pool."""
         self._http.close()
 
+    @property
+    def authorization_header(self) -> dict[str, str]:
+        """Return the current Bearer authorization header dict.
+
+        Returns ``{"Authorization": "Bearer <token>"}`` if authenticated,
+        or ``{}`` if not.
+        """
+        return self._auth.authorization_header
+
     # -- health (unauthenticated) --------------------------------------------
 
     def health(self) -> HealthResponse:


### PR DESCRIPTION
## Summary

Resolve all 5 violations from issue #92 by applying Clean Code principles across the `/scripts` folder:

1. **Function Naming** — Disambiguate `submit_log_running_task` → `submit_long_running_task`
2. **DRY Principle** — Extract duplicate Ollama HTTP helpers to `_ollama.py`
3. **Magic Numbers** — Replace hardcoded 409 with `HTTP_CONFLICT` constant
4. **Module Imports** — Move `import uuid` from function body to module level
5. **Encapsulation** — Add public `authorization_header` property to SDK Client

## Changes

- ✅ Created `scripts/_ollama.py` with shared Ollama utilities
- ✅ Refactored `eval_models.py`, `query_model.py`, `rag_query.py` to use shared module
- ✅ Added `HTTP_CONFLICT` constant to `seed_demo.py`
- ✅ Cleaned up imports in `seed_demo.py`
- ✅ Added public property to `sdk/gideon/client.py`
- ✅ Updated `upload_file.py` to use public API

## Verification

- ✅ All syntax validated
- ✅ Ruff formatting checks passed
- ✅ Pytest tests passed
- ✅ Code review completed with no violations
- ✅ DRY principle successfully applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)