### PR TITLE
docs(#107): Expand CLI README with quickstart guide

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -9,10 +9,107 @@ Command-line interface for the Gideon API, built on the
 uv sync
 ```
 
-## Usage
+The `gideon` command is available in the activated virtual environment.
+
+## Configuration
+
+The CLI resolves settings via a four-layer precedence chain (highest to lowest):
+
+1. **CLI flags** — `gideon --base-url http://api:8000 health`
+2. **Environment variables** — `GIDEON_BASE_URL=http://api:8000`
+3. **Config file** — `~/.gideon/config.toml`
+4. **Defaults** — `http://localhost:8000`, 30s timeout
+
+**Interactive setup:** Run `gideon configure` to set your API URL and timeout interactively.
+
+## Quick Start
 
 ```bash
-gideon --help
+# 1. Set API URL interactively
+gideon configure
+
+# 2. Verify the API is reachable
 gideon health
-gideon login --email user@firm.com
+
+# 3. Authenticate (prompts for email, password, and TOTP if MFA is enabled)
+gideon login
+
+# 4. List matters you have access to
+gideon matter list
 ```
+
+## Command Reference
+
+### Health & Status
+- `gideon health` — API health status
+- `gideon ready` — readiness + service dependency checks
+
+### Authentication
+- `gideon login` — authenticate (interactive or with `--email`, `--password`, `--totp-code`)
+- `gideon logout` — invalidate session and clear local tokens
+- `gideon whoami` — show authenticated user, role, and firm
+
+### Multi-Factor Authentication
+- `gideon mfa setup` — begin TOTP setup, display secret and provisioning URI
+- `gideon mfa confirm` — confirm MFA with a TOTP code
+- `gideon mfa disable` — disable MFA with a TOTP code
+
+### Users
+- `gideon user list` — list all firm users
+- `gideon user get <user-id>` — get user details
+- `gideon user create` — create a new user (requires `--email`, `--password`, `--first-name`, `--last-name`, `--role`)
+- `gideon user update <user-id>` — update user fields
+
+### Matters (Cases)
+- `gideon matter list` — list all matters
+- `gideon matter get <matter-id>` — get matter details
+- `gideon matter create` — create a new matter (requires `--name`, `--client-id`)
+- `gideon matter update <matter-id>` — update matter fields (e.g., `--status`)
+- `gideon matter access-list <matter-id>` — list users with access
+- `gideon matter access-grant <matter-id>` — grant user access (with optional `--view-work-product`)
+- `gideon matter access-revoke <matter-id>` — revoke user access
+
+### Documents
+- `gideon document list` — list all documents
+- `gideon document get <document-id>` — get document details
+- `gideon document upload` — upload a single file (requires `--matter-id` and file path)
+- `gideon document bulk-ingest` — upload all supported files from a directory (requires `--matter-id` and directory path)
+- `gideon document re-ingest` — re-queue a failed document or all failed documents
+
+### Prompts (AI Chat)
+- `gideon prompt list` — list submitted prompts
+- `gideon prompt get <prompt-id>` — get prompt details
+- `gideon prompt submit` — submit a query to the AI chatbot (requires `--matter-id` and query text)
+
+### Background Tasks
+- `gideon task list` — list background tasks (filter with `--status` or `--task-name`)
+- `gideon task get <task-id>` — get task details including result and traceback
+- `gideon task submit` — submit a background task (requires `--task-name`)
+- `gideon task cancel` — cancel a pending or running task
+
+### Firm
+- `gideon firm get` — show current firm details
+
+### Utility
+- `gideon configure` — set API URL and timeout interactively
+- `gideon version` — show CLI and SDK versions
+
+## Global Options
+
+All commands accept these flags:
+
+- `--base-url` (env: `GIDEON_BASE_URL`) — API base URL (default: `http://localhost:8000`)
+- `--timeout` (env: `GIDEON_TIMEOUT`) — Request timeout in seconds (default: `30`)
+- `--json` — Output as JSON (machine-readable)
+
+## Token Storage
+
+Authentication tokens (access + refresh JWT) are stored securely at `~/.gideon/tokens.json`:
+- **Unix/Linux:** mode `0600` (owner-only read/write)
+- **Windows:** standard file ACLs apply
+- Cleared when you run `gideon logout`
+
+## Full Reference
+
+See [docs/CLI.md](../docs/CLI.md) for the complete CLI reference including all command flags,
+detailed examples, option tables, and configuration details.

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -30,6 +30,8 @@ BDD scenarios.*
 
 ### Reference
 
+- [CLI Reference](CLI.md) — Complete CLI command reference,
+  all flags, examples, and configuration
 - [Settings Reference](SETTINGS.md) — all environment variables,
   defaults, and configuration classes
 - [Infrastructure Reference](INFRASTRUCTURE.md) — Docker Compose

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,17 +1,238 @@
 # gideon-sdk
 
-Python REST client for the Gideon API.
+Python REST client for the Gideon API, providing a synchronous, type-safe
+interface with automatic JWT token management, error mapping, and thread-safe
+operations.
 
-## Usage
+## Installation
+
+From the repo root, run:
+
+```bash
+uv sync
+```
+
+The `gideon-sdk` package is available in the Python environment once the workspace is
+synced. Import as:
+
+```python
+from gideon import Client, Session
+```
+
+## Configuration
+
+The client accepts a base URL pointing to the Gideon FastAPI server:
+
+```python
+from gideon import Client
+
+# Basic setup
+client = Client(base_url="http://localhost:8000")
+
+# With custom timeout (seconds)
+client = Client(base_url="http://localhost:8000", timeout=60.0)
+```
+
+The client handles JWT authentication transparently: after `login()`, all
+subsequent requests automatically include the JWT and refresh it when needed
+(with a 30-second expiry buffer).
+
+## Quick Start
+
+### Basic Authentication Flow
 
 ```python
 from gideon import Client
 
 client = Client(base_url="http://localhost:8000")
-client.login(email="user@firm.com", password="secret")
 
-health = client.health()
-print(health.status)
+# Authenticate
+client.login(email="attorney@firm.com", password="secret")
 
+# Verify access
+me = client.get_current_user()
+print(f"Logged in as: {me.email} ({me.role})")
+
+# Logout
 client.logout()
 ```
+
+### Working with Matters (Legal Cases)
+
+```python
+# List all matters you have access to
+matters = client.list_matters()
+for matter in matters:
+    print(f"Matter: {matter.name} (ID: {matter.id})")
+
+# Get specific matter
+matter = client.get_matter(matter_id="<uuid>")
+print(f"Status: {matter.status}, Client: {matter.client_id}")
+
+# Create a new matter
+new_matter = client.create_matter(
+    name="People v. Smith",
+    client_id="<client-uuid>"
+)
+```
+
+### Managing Users
+
+```python
+# List firm users
+users = client.list_users()
+for user in users:
+    print(f"{user.email} ({user.role})")
+
+# Create new user
+new_user = client.create_user(
+    email="newatty@firm.com",
+    password="SecurePass123!",
+    first_name="Jane",
+    last_name="Doe",
+    role="attorney"  # admin, attorney, paralegal, investigator
+)
+
+# Update user
+client.update_user(
+    user_id="<uuid>",
+    first_name="Janet"
+)
+```
+
+### Uploading Documents
+
+```python
+# Upload a single document
+response = client.upload_document(
+    file_path="./evidence.pdf",
+    matter_id="<matter-uuid>",
+    source="defense",  # defense, government_production, court, work_product
+    classification="brady",  # brady, giglio, jencks, rule16, work_product, unclassified
+    bates_number="SMITH_001"
+)
+print(f"Uploaded: {response.id}")
+
+# Check for duplicate before upload
+file_hash = client.hash_file("./evidence.pdf")
+is_duplicate = client.check_duplicate(
+    matter_id="<matter-uuid>",
+    file_hash=file_hash
+)
+if not is_duplicate:
+    client.upload_document(...)
+```
+
+### Submitting Queries
+
+```python
+# Submit a question to the AI chatbot
+response = client.submit_prompt(
+    matter_id="<matter-uuid>",
+    query="What Brady material exists in this case?"
+)
+print(f"Query ID: {response.id}")
+
+# Retrieve prompt results
+prompt = client.get_prompt(prompt_id="<uuid>")
+print(f"Query: {prompt.query}")
+```
+
+### Managing Background Tasks
+
+```python
+# Submit a background task
+task = client.submit_task(
+    task_name="ping",
+    args=[],
+    kwargs={}
+)
+print(f"Task ID: {task.id}, Status: {task.status}")
+
+# Monitor task progress
+task = client.get_task(task_id="<uuid>")
+print(f"Status: {task.status}, Result: {task.result}")
+
+# List tasks with filtering
+tasks = client.list_tasks(status="pending")
+for task in tasks:
+    print(f"{task.task_name}: {task.status}")
+
+# Cancel a task
+client.cancel_task(task_id="<uuid>")
+```
+
+### Using Context Manager
+
+For automatic login/logout, use the `Session` context manager:
+
+```python
+from gideon import Session
+
+with Session(
+    base_url="http://localhost:8000",
+    email="attorney@firm.com",
+    password="secret"
+) as client:
+    matters = client.list_matters()
+    # Token management and logout handled automatically
+```
+
+## Core Features
+
+- **Automatic Token Management**: JWT tokens are refreshed transparently with a
+  30-second expiry buffer. If a token expires, the client automatically retries
+  the request once after refreshing.
+
+- **Type Safety**: All API responses are validated against Pydantic models from
+  `gideon-shared`, ensuring type correctness and IDE autocomplete support.
+
+- **Thread Safety**: The internal token manager uses locks to safely handle
+  concurrent requests and token refresh across multiple threads.
+
+- **Error Mapping**: HTTP errors are mapped to specific exception types
+  (`AuthenticationError`, `AuthorizationError`, `NotFoundError`,
+  `ValidationError`, `ServerError`) for precise error handling.
+
+- **Matter-Based Access Control**: All document and prompt operations are
+  scoped to a specific matter; the API filters results based on your access
+  grants.
+
+- **File Hashing**: Built-in SHA-256 file hashing for duplicate detection before upload.
+
+- **MFA Support**: Complete multi-factor authentication workflow (setup, confirm, disable).
+
+- **Task Queue Integration**: Submit, monitor, and cancel background jobs (ingestion,
+  processing, etc.).
+
+## Error Handling
+
+```python
+from gideon import Client
+from gideon.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    NotFoundError,
+    ValidationError,
+    ServerError
+)
+
+client = Client(base_url="http://localhost:8000")
+
+try:
+    client.login(email="bad@firm.com", password="wrong")
+except AuthenticationError as e:
+    print(f"Login failed: {e}")
+
+try:
+    matters = client.list_matters()
+except AuthorizationError as e:
+    print(f"Access denied: {e}")
+except ServerError as e:
+    print(f"API error: {e}")
+```
+
+## CLI Alternative
+
+For command-line interaction, see [`../cli/README.md`](../cli/README.md) for the
+`gideon` CLI tool, which wraps this SDK and provides shell commands for all operations.


### PR DESCRIPTION
## Summary

Resolves #107: CLI and SDK READMEs were insufficient. Expanded both with proper installation, configuration, quickstart guides, and feature overviews, while maintaining reference documentation in docs/.

## Changes

### cli/README.md
Expanded from 3-line stub to comprehensive quickstart:
- Configuration (4-layer precedence: flags → env vars → config file → defaults)
- Quick start workflow (configure → health → login → matter list)
- Complete command reference organized by feature area (Health, Auth, MFA, Users, Matters, Documents, Prompts, Tasks, Firm, Utility)
- Global options (`--base-url`, `--timeout`, `--json`)
- Token storage details
- Link to `docs/CLI.md` for full reference with detailed flags

### sdk/README.md
Expanded from basic example to comprehensive guide:
- Installation instructions (uv sync)
- Configuration and setup section
- Quick start examples covering: authentication, matters, users, documents, prompts, tasks, context manager
- Core Features section explaining: automatic token management, type safety, thread safety, error mapping, access control, file hashing, MFA, task queue
- Error handling section with try/except examples
- Reference to CLI tool as alternative interface

### docs/TOC.md
Added CLI reference entry under Reference section for better discoverability

## Design

Two-tier documentation:
- **Package-local READMEs** (`cli/README.md`, `sdk/README.md`) serve as quickstart guides for developers
- **Reference docs** (`docs/CLI.md`) provide comprehensive details with examples, flags, and tables
- No duplication: each file has a distinct purpose

## Testing

- Verified command/method references match actual implementations
- Confirmed relative links resolve correctly
- All tests pass (pytest backend, sdk, cli)

🤖 Generated with Claude Code