### PR TITLE
refactor(#105): Make DocumentListResponse generic

### DIFF
--- a/shared/shared/models/__init__.py
+++ b/shared/shared/models/__init__.py
@@ -11,13 +11,14 @@ from shared.models.auth import (
     RefreshRequest,
     TokenResponse,
 )
-from shared.models.base import MessageResponse
+from shared.models.base import ListResponse, MessageResponse
 from shared.models.chat import (
     ChatQueryResponse,
     ChatSessionResponse,
     SubmitQueryRequest,
 )
 from shared.models.document import (
+    DocumentListResponse,
     DocumentResponse,
     DocumentSummary,
 )
@@ -62,12 +63,14 @@ __all__ = [
     "ChatSessionResponse",
     "SubmitQueryRequest",
     "CreateUserRequest",
+    "DocumentListResponse",
     "DocumentResponse",
     "DocumentSource",
     "DocumentSummary",
     "FirmResponse",
     "GrantAccessRequest",
     "HealthResponse",
+    "ListResponse",
     "LoginRequest",
     "LogoutRequest",
     "MatterAccessResponse",

--- a/shared/shared/models/base.py
+++ b/shared/shared/models/base.py
@@ -3,5 +3,14 @@
 from pydantic import BaseModel
 
 
+class ListResponse[T](BaseModel):
+    """Generic paginated list envelope."""
+
+    items: list[T]
+    total: int
+    offset: int
+    limit: int
+
+
 class MessageResponse(BaseModel):
     detail: str

--- a/shared/shared/models/document.py
+++ b/shared/shared/models/document.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from shared.models.base import ListResponse
 from shared.models.enums import Classification, DocumentSource, IngestionStatus
 
 # ---------------------------------------------------------------------------
@@ -37,13 +38,7 @@ class DocumentResponse(DocumentSummary):
     updated_at: datetime
 
 
-class DocumentListResponse(BaseModel):
-    """Paginated document listing."""
-
-    items: list[DocumentSummary]
-    total: int
-    offset: int
-    limit: int
+DocumentListResponse = ListResponse[DocumentSummary]
 
 
 class ReIngestResponse(BaseModel):


### PR DESCRIPTION
## Summary

Introduce a generic `ListResponse[T]` class in `shared.models.base` to support paginated list responses across all endpoints. Replace `DocumentListResponse` with a typed alias, and export both from the shared models package.

## Changes

- **shared/shared/models/base.py**: Add `ListResponse[T]` generic class with `items`, `total`, `offset`, `limit` fields
- **shared/shared/models/document.py**: Replace `DocumentListResponse` class with type alias `= ListResponse[DocumentSummary]`
- **shared/shared/models/__init__.py**: Export `ListResponse` and `DocumentListResponse` from the shared models package

## Benefits

- Enables future endpoints (matters, users, tasks) to reuse the same pagination envelope pattern
- Reduces code duplication and improves consistency across list endpoints
- Maintains backwards compatibility — JSON schema and response contract unchanged

## Testing

✅ All 13 document listing tests pass
✅ mypy type checking passes
✅ Pre-commit hooks pass (ruff formatting and lint)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>