### PR TITLE
fix: Protect ollama models in integration tests; update volume documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,9 +108,14 @@ Integration tests require Docker and pull several service images.
    For manual stack control:
 
    ```bash
-   docker compose -f infrastructure/docker-compose.integration.yml up -d
-   uv run pytest backend/tests/
-   docker compose -f infrastructure/docker-compose.integration.yml down
+   docker compose -f infrastructure/docker-compose.yml \
+     -f infrastructure/docker-compose.integration.yml \
+     --env-file backend/.env.test \
+     -p gideon-test up -d
+   uv run pytest backend/tests/ -m integration
+   docker compose -f infrastructure/docker-compose.yml \
+     -f infrastructure/docker-compose.integration.yml \
+     -p gideon-test down -v
    ```
 
 For a persistent local environment (non-development), see

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,9 +80,18 @@ Integration tests require Docker and pull several service images.
 - `ollama/ollama:latest` — Local LLM inference
 - `ghcr.io/grafana/otel-lgtm:latest` — Observability stack
 
-**Before running integration tests:**
+**Before running integration tests (one-time setup):**
 
-1. Pull the backend image (or build locally):
+1. Create the persistent test Ollama models volume (one-time):
+
+   ```bash
+   docker volume create gideon-ollama-models-test
+   ```
+
+   This volume caches LLM models across integration test runs to avoid re-downloading
+   multi-GB models on each test cycle.
+
+2. Pull the backend image (or build locally):
 
    ```bash
    # Option A: Pull from GitHub Container Registry
@@ -94,7 +103,7 @@ Integration tests require Docker and pull several service images.
 
    All other images are pulled automatically by Docker Compose during test startup.
 
-2. Run integration tests:
+3. Run integration tests:
 
    ```bash
    uv run pytest backend/tests/ -m integration

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -35,7 +35,6 @@ step.
 
 - Docker Compose 2.0+
 - `.env` file (copy from `.env.example` and fill in secrets)
-- External Docker volumes for persistent data:
 
 ### Pulling Pre-Built Images
 
@@ -113,8 +112,8 @@ docker compose -f docker-compose.yml \
 
 Integration tests use the `docker-compose.integration.yml` override, which:
 
-1. **Uses ephemeral volumes** for all services — data is wiped between test
-   runs for a clean slate
+1. **Uses ephemeral test volumes** for postgres, qdrant, minio, and ollama
+   — data is wiped between test runs for a clean slate
 2. **Enables OTEL tracing** with the OTLP exporter to Grafana (otel-lgtm)
 3. **Disables Flower** (not needed for tests)
 
@@ -130,10 +129,10 @@ pytest -m integration
 
 This will:
 
-1. Create/start all services with ephemeral volumes
+1. Create/start all services (with ephemeral test volumes)
 2. Run tests against `gideon_test` and `gideon_tasks_test` databases
 3. Tear down services with `docker compose down -v` (removes all ephemeral
-   volumes)
+   test volumes)
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -112,8 +112,9 @@ docker compose -f docker-compose.yml \
 
 Integration tests use the `docker-compose.integration.yml` override, which:
 
-1. **Uses ephemeral test volumes** for postgres, qdrant, minio, and ollama
-   — data is wiped between test runs for a clean slate
+1. **Uses ephemeral test volumes** for postgres, qdrant, and minio — data is
+   wiped between test runs for a clean slate. The `ollama-models-test` volume
+   is persistent (external) so LLM models are cached across test runs
 2. **Enables OTEL tracing** with the OTLP exporter to Grafana (otel-lgtm)
 3. **Disables Flower** (not needed for tests)
 
@@ -129,10 +130,10 @@ pytest -m integration
 
 This will:
 
-1. Create/start all services (with ephemeral test volumes)
+1. Create/start all services (ephemeral test volumes for postgres, qdrant, minio)
 2. Run tests against `gideon_test` and `gideon_tasks_test` databases
-3. Tear down services with `docker compose down -v` (removes all ephemeral
-   test volumes)
+3. Tear down services with `docker compose down -v` (removes ephemeral test
+   volumes; ollama-models-test is preserved)
 
 ---
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -58,19 +58,10 @@ docker compose -f infrastructure/docker-compose.yml --env-file .env down
 docker compose -f infrastructure/docker-compose.yml --env-file .env down -v
 ```
 
-#### Automated setup
+#### Using an anonymous Ollama volume
 
-To automate volume creation:
-
-```bash
-bash scripts/setup-volumes.sh
-docker compose -f infrastructure/docker-compose.yml --env-file .env up
-```
-
-#### Using a local (ephemeral) Ollama volume
-
-For local development or CI environments where you don't mind re-downloading
-models on each restart:
+For local development or CI environments where you want a clean Ollama state
+on each restart (models will be re-downloaded):
 
 ```bash
 cp infrastructure/docker-compose.override.yml.example \
@@ -78,8 +69,10 @@ cp infrastructure/docker-compose.override.yml.example \
 docker compose -f infrastructure/docker-compose.yml --env-file .env up
 ```
 
-This overrides the `ollama-models` volume to be local and ephemeral, deleted
-when you run `docker compose down -v`.
+This overrides `ollama-models` from the default named volume
+(`gideon-ollama-models`) to an anonymous volume, which Docker discards
+when you run `docker compose down -v`. Models will be re-downloaded on the
+next `up`.
 
 #### Enable the frontend
 
@@ -393,13 +386,20 @@ Used as the Celery broker. Not exposed outside the Docker network.
 
 | Volume | Service | Contents |
 | --- | --- | --- |
+| `postgres-data` | postgres | Relational database (named: `gideon-postgres-data`) |
+| `qdrant-data` | qdrant, qdrant-init | Vector store collection data (named: `gideon-qdrant-data`) |
+| `ollama-models` | ollama, ollama-init | LLM model weights (named: `gideon-ollama-models`) |
+| `minio-data` | minio | Object store buckets and objects (named: `gideon-minio-data`) |
 | `redis-data` | redis | Redis AOF persistence |
-| `minio-data` | minio | Object store buckets and objects |
-| `celery-tmp` | celery-worker | Ephemeral temp files during ingestion |
+| `celery-tmp` | celery-worker, celery-beat | Ephemeral temp files during ingestion |
 | `grafana-data` | grafana | Grafana dashboards, Tempo traces, Prometheus metrics, Loki logs |
 
 All volumes are named (managed by Docker). Deleting volumes wipes the
 corresponding data permanently.
+
+`postgres-data`, `qdrant-data`, `ollama-models`, and `minio-data` use explicit
+`name:` keys (`gideon-*`) for stable, predictable names on the Docker host
+independent of the Compose project name.
 
 ---
 
@@ -444,11 +444,13 @@ automatically by `pytest-docker` (configured in `backend/tests/conftest.py`).
 - `fastapi` has OTel enabled (`EXPORTER=otlp`, targeting `grafana:4318`)
 - `redis` exposes port `6379` to the host for test access
 - `celery-worker` result backend points at `gideon_tasks_test`
-- `minio` exposes ports `9000` and `9001` to the host for test access
+- `minio` uses `minio-data-test` (ephemeral test volume)
+- `ollama` uses `ollama-models-test` (ephemeral — models re-downloaded after teardown)
 - `flower` is disabled (not needed for tests)
 - `nextjs` is disabled via profiles in the base compose file
-- `qdrant` exposes port `6333` to the host for test access
+- `qdrant` uses `qdrant-data-test` (ephemeral test volume)
 - `qdrant-init` overrides collection name to `gideon_test`
+- `postgres` uses `postgres-data-test` (ephemeral test volume)
 - Active services: `postgres` + `redis` + `minio` + `qdrant` + `ollama` +
   `fastapi` + `celery-worker` + `celery-beat` + `grafana`
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -445,7 +445,7 @@ automatically by `pytest-docker` (configured in `backend/tests/conftest.py`).
 - `redis` exposes port `6379` to the host for test access
 - `celery-worker` result backend points at `gideon_tasks_test`
 - `minio` uses `minio-data-test` (ephemeral test volume)
-- `ollama` uses `ollama-models-test` (ephemeral — models re-downloaded after teardown)
+- `ollama` uses `ollama-models-test` (persistent external volume; models cached across test runs)
 - `flower` is disabled (not needed for tests)
 - `nextjs` is disabled via profiles in the base compose file
 - `qdrant` uses `qdrant-data-test` (ephemeral test volume)

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -54,6 +54,8 @@ docker compose -f infrastructure/docker-compose.yml --env-file .env up -d
 # Stop and remove containers (preserve volumes)
 docker compose -f infrastructure/docker-compose.yml --env-file .env down
 
+# NOT RECOMMENDED
+# NOTE: After you have run ingestion for hours you will LOSE ALL YOUR DATA
 # Stop and wipe all volumes (clean slate)
 docker compose -f infrastructure/docker-compose.yml --env-file .env down -v
 ```
@@ -155,8 +157,8 @@ does not stay running.
 
 | Setting | Value |
 | --- | --- |
-| Build context | `../backend` |
-| Dockerfile | `docker/Dockerfile` |
+| Build context | `..` (repo root) |
+| Dockerfile | `backend/docker/Dockerfile` |
 | Command | `["true"]` (entrypoint runs migrations, then `exec true` exits) |
 | Depends on | `postgres` (healthy) |
 | Restart | `no` |

--- a/docs/LOCAL_DEPLOYMENT.md
+++ b/docs/LOCAL_DEPLOYMENT.md
@@ -59,7 +59,13 @@ docker compose -f infrastructure/docker-compose.yml --env-file .env up -d
 Docker Compose automatically creates the named volumes defined in the
 compose file:
 
-- `minio-data` — MinIO S3 documents and extracted text
+- `postgres-data` — relational database (named: `gideon-postgres-data`)
+- `qdrant-data` — vector store collection data (named: `gideon-qdrant-data`)
+- `ollama-models` — LLM model weights; persists across restarts (named: `gideon-ollama-models`)
+- `minio-data` — MinIO S3 documents and extracted text (named: `gideon-minio-data`)
+- `redis-data` — Redis AOF persistence
+- `grafana-data` — Grafana dashboards, Tempo traces, Prometheus metrics, Loki logs
+- `celery-tmp` — ephemeral scratch space for Celery workers
 
 These volumes **persist across restarts** until you explicitly delete them.
 To preserve data when stopping the stack:

--- a/infrastructure/docker-compose.integration.yml
+++ b/infrastructure/docker-compose.integration.yml
@@ -10,7 +10,7 @@
 #   - Disables services not needed for tests (nextjs, flower)
 #   - Services started: postgres, redis, minio, minio-init, qdrant, qdrant-init, ollama, ollama-init, tika, fastapi, celery-worker, celery-beat, grafana
 #   - Uses ephemeral volumes for postgres, qdrant, minio (clean per test run)
-#   - Uses ollama-models-test (ephemeral per test run; models re-downloaded after teardown)
+#   - Uses ollama-models-test (persistent external volume; models cached across test runs)
 #   - Enables OTEL tracing via http://grafana:4318
 #   - Tears down with -v so ephemeral volumes are wiped between runs
 
@@ -69,7 +69,12 @@ services:
     ports:
       - "11434:11434"
     volumes:
-      # Ephemeral volume: cleaned between test runs
+      # Persistent external volume: cached across test runs
+      - ollama-models-test:/root/.ollama
+
+  ollama-init:
+    volumes:
+      # Same persistent external volume as ollama service
       - ollama-models-test:/root/.ollama
 
   qdrant:

--- a/infrastructure/docker-compose.integration.yml
+++ b/infrastructure/docker-compose.integration.yml
@@ -10,7 +10,7 @@
 #   - Disables services not needed for tests (nextjs, flower)
 #   - Services started: postgres, redis, minio, minio-init, qdrant, qdrant-init, ollama, ollama-init, tika, fastapi, celery-worker, celery-beat, grafana
 #   - Uses ephemeral volumes for postgres, qdrant, minio (clean per test run)
-#   - Keeps ollama-models as external volume (models cached across tests)
+#   - Uses ollama-models-test (ephemeral per test run; models re-downloaded after teardown)
 #   - Enables OTEL tracing via http://grafana:4318
 #   - Tears down with -v so ephemeral volumes are wiped between runs
 
@@ -68,6 +68,9 @@ services:
   ollama:
     ports:
       - "11434:11434"
+    volumes:
+      # Ephemeral volume: cleaned between test runs
+      - ollama-models-test:/root/.ollama
 
   qdrant:
     ports:
@@ -97,3 +100,4 @@ volumes:
   postgres-data-test:
   qdrant-data-test:
   minio-data-test:
+  ollama-models-test:

--- a/infrastructure/docker-compose.integration.yml
+++ b/infrastructure/docker-compose.integration.yml
@@ -101,3 +101,5 @@ volumes:
   qdrant-data-test:
   minio-data-test:
   ollama-models-test:
+    external: true
+    name: gideon-ollama-models-test

--- a/infrastructure/docker-compose.override.yml.example
+++ b/infrastructure/docker-compose.override.yml.example
@@ -1,33 +1,19 @@
 # docker-compose.override.yml.example
 #
-# Use this override to opt out of the external Ollama models volume.
-# Models will be re-downloaded on each stack restart (slower, but simpler).
+# Use this override to make the ollama-models volume anonymous so that
+# LLM models are NOT cached between stack restarts.
+# Models will be re-downloaded on each `docker compose up` (slower startup).
 #
 # Usage:
 #   cp infrastructure/docker-compose.override.yml.example infrastructure/docker-compose.override.yml
-#   docker compose -f infrastructure/docker-compose.yml up
+#   docker compose -f infrastructure/docker-compose.yml --env-file .env up
 #
-# Docker Compose will automatically apply the override and use a local volume
-# that is deleted when you run `docker compose down -v`.
-
-version: "3.9"
+# Docker Compose will automatically apply the override. The anonymous volume
+# is deleted when you run `docker compose down -v`.
 
 volumes:
-  postgres-data:
-    # Override the external volume to use a local (ephemeral) volume instead.
-    # This is useful for:
-    # - CI/CD runners where persistence across runs isn't needed
-    # - Local development where you want a completely clean state
-    # - Test runs with fresh database
-    external: false
-    name: postgres-data
-  qdrant-data:
-    # Similarly, override Qdrant to use an ephemeral volume.
-    # Useful if you want to reingest documents from scratch on each restart.
-    external: false
-    name: qdrant-data
   ollama-models:
-    # Override Ollama to use an ephemeral volume.
-    # Models will be re-downloaded on each restart (slower startup).
-    external: false
-    name: ollama-models
+    # Anonymous volume — no name, no external flag.
+    # Replaces gideon-ollama-models with an unnamed volume that Docker discards
+    # on `docker compose down -v`. Use this when you want a clean Ollama state
+    # on each restart.

--- a/infrastructure/docker-compose.override.yml.example
+++ b/infrastructure/docker-compose.override.yml.example
@@ -10,6 +10,10 @@
 #
 # Docker Compose will automatically apply the override. The anonymous volume
 # is deleted when you run `docker compose down -v`.
+#
+# Note: postgres-data, qdrant-data, and minio-data are no longer external volumes
+# in the base compose, so they are not included in this override. They already
+# auto-create as named volumes and survive `down -v` in dev.
 
 volumes:
   ollama-models:

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -477,6 +477,7 @@ volumes:
   ollama-models:
     name: gideon-ollama-models
   minio-data:
+    name: gideon-minio-data
   celery-tmp:
   grafana-data:
 


### PR DESCRIPTION
## Summary

Fixes integration test volume handling to prevent re-downloading LLM models on every test run.

**The Problem:** Integration tests were deleting the persistent `gideon-ollama-models` volume on teardown (via `docker compose down -v`), forcing Ollama to re-download multi-GB LLM models on each test cycle.

**The Solution:**
- Add `ollama-models-test` as an external persistent volume in the integration overlay, so the ollama service uses an isolated test volume that survives teardown
- Add explicit `name: gideon-minio-data` to minio-data in the base compose for consistency
- Rewrite `docker-compose.override.yml.example` to only override ollama-models (removed stale postgres/qdrant entries)
- Update all documentation to clarify which volumes are persistent vs. ephemeral and their naming convention

**Volume Strategy (after fix):**
- **Dev stack:** postgres, qdrant, minio, ollama all use persistent named volumes (`gideon-*`) that survive `down` and `down -v`
- **Integration tests:** postgres, qdrant, minio redirect to ephemeral `*-test` volumes (wiped on teardown); ollama uses persistent `gideon-ollama-models-test` (cached across runs)
- **One-time setup:** `docker volume create gideon-ollama-models-test` required before first integration test run

## Test Plan

- [ ] Run integration tests: `cd backend && uv run pytest -m integration`
  - First run: Ollama downloads models into `gideon-ollama-models-test`
  - Subsequent runs: Models are reused from cache
  - Verify no model re-downloads on each test cycle
- [ ] Verify manual stack control works: follow commands in CONTRIBUTING.md
- [ ] Check that dev stack persists data: `docker compose down` then `up` should preserve documents, vectors, etc.
- [ ] Verify override example works: copy to `docker-compose.override.yml`, start stack, confirm Ollama rebuilds models on each `up`

## Files Changed
- `infrastructure/docker-compose.yml` — add explicit name to minio-data
- `infrastructure/docker-compose.integration.yml` — add ollama-models-test override + volume
- `infrastructure/docker-compose.override.yml.example` — rewrite (only ollama-models)
- `CONTRIBUTING.md` — add one-time setup step, fix manual command
- `docs/DEPLOYMENT.md` — clarify ephemeral vs. persistent volumes
- `docs/INFRASTRUCTURE.md` — expand volumes table, remove setup-volumes.sh ref, update comments
- `docs/LOCAL_DEPLOYMENT.md` — expand volume list

🤖 Generated with [Claude Code](https://claude.com/claude-code)