### PR TITLE
fix: Add monitoring dependency group for Flower service

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -29,7 +29,7 @@ COPY backend/scripts/ scripts/
 # INSTALL_EXTRAS is empty by default; set to "monitoring" for the Flower container.
 ARG INSTALL_EXTRAS=""
 RUN if [ -n "$INSTALL_EXTRAS" ]; then \
-      uv sync --frozen --no-dev --no-editable --extra "$INSTALL_EXTRAS"; \
+      uv sync --frozen --no-dev --no-editable --group "$INSTALL_EXTRAS"; \
     else \
       uv sync --frozen --no-dev --no-editable; \
     fi

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -89,6 +89,9 @@ dev = [
     "psycopg2-binary>=2.9",
     "flower>=2.0",
 ]
+monitoring = [
+    "flower>=2.0",
+]
 
 [tool.uv.sources]
 gideon-shared = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -1098,6 +1098,9 @@ dev = [
     { name = "ruff" },
     { name = "types-python-jose" },
 ]
+monitoring = [
+    { name = "flower" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1149,6 +1152,7 @@ dev = [
     { name = "ruff", specifier = ">=0.9" },
     { name = "types-python-jose", specifier = ">=3.3" },
 ]
+monitoring = [{ name = "flower", specifier = ">=2.0" }]
 
 [[package]]
 name = "gideon-cli"


### PR DESCRIPTION
## Summary

Fixes the Flower (Celery monitoring UI) container failing to start due to the `flower` Python package not being installed in the production Docker image.

## Root Cause

The Dockerfile attempts to install a `monitoring` dependency group via `uv sync --extra monitoring`, but `--extra` reads from `[project.optional-dependencies]` (which didn't exist). The `flower` package was only in `[dependency-groups] dev`, which is excluded by `--no-dev` during Docker build.

## Changes

- Added `[dependency-groups] monitoring = ["flower>=2.0"]` to `backend/pyproject.toml`
- Updated `backend/docker/Dockerfile` to use `--group` instead of `--extra` (PEP 735 standard)
- Regenerated `uv.lock` to record the new monitoring group

## Verification

- ✅ All 450 unit tests pass
- ✅ All pre-commit hooks pass
- ✅ Lockfile correctly records the `monitoring` group

## Related

Resolves: #132

🤖 Generated with Claude Code